### PR TITLE
【第5回】記事管理 impl claude prompt simple

### DIFF
--- a/app/(dashboard)/dashboard/articles/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/articles/[id]/edit/page.tsx
@@ -1,0 +1,32 @@
+import { ArticleForm } from '@/components/article-form';
+import { getArticleById } from '@/lib/db/queries';
+import { notFound } from 'next/navigation';
+
+export default async function EditArticlePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const article = await getArticleById(parseInt(id));
+
+  if (!article) {
+    notFound();
+  }
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <h1 className="text-lg lg:text-2xl font-medium mb-6">Edit Article</h1>
+      <ArticleForm
+        article={{
+          id: article.id,
+          title: article.title,
+          slug: article.slug,
+          content: article.content,
+          excerpt: article.excerpt,
+          status: article.status,
+        }}
+      />
+    </section>
+  );
+}

--- a/app/(dashboard)/dashboard/articles/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/articles/[id]/page.tsx
@@ -1,0 +1,69 @@
+import { getArticleById } from '@/lib/db/queries';
+import { notFound } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import Link from 'next/link';
+import { Pencil } from 'lucide-react';
+
+export default async function ArticleDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const article = await getArticleById(parseInt(id));
+
+  if (!article) {
+    notFound();
+  }
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return 'N/A';
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-lg lg:text-2xl font-medium">Article Details</h1>
+        <Link href={`/dashboard/articles/${article.id}/edit`}>
+          <Button variant="outline">
+            <Pencil className="mr-2 h-4 w-4" />
+            Edit
+          </Button>
+        </Link>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl">{article.title}</CardTitle>
+          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+            <span className="capitalize">{article.status}</span>
+            <span>•</span>
+            <span>By {article.authorName || article.authorEmail}</span>
+            <span>•</span>
+            <span>
+              {article.status === 'published'
+                ? `Published ${formatDate(article.publishedAt)}`
+                : `Created ${formatDate(article.createdAt)}`}
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {article.excerpt && (
+            <div className="p-4 bg-muted rounded-lg">
+              <p className="text-sm italic">{article.excerpt}</p>
+            </div>
+          )}
+          <div className="prose prose-sm max-w-none dark:prose-invert">
+            <div className="whitespace-pre-wrap">{article.content}</div>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/(dashboard)/dashboard/articles/new/page.tsx
+++ b/app/(dashboard)/dashboard/articles/new/page.tsx
@@ -1,0 +1,10 @@
+import { ArticleForm } from '@/components/article-form';
+
+export default function NewArticlePage() {
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <h1 className="text-lg lg:text-2xl font-medium mb-6">Create New Article</h1>
+      <ArticleForm />
+    </section>
+  );
+}

--- a/app/(dashboard)/dashboard/articles/page.tsx
+++ b/app/(dashboard)/dashboard/articles/page.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useRouter } from 'next/navigation';
+import useSWR from 'swr';
+import Link from 'next/link';
+import { PlusCircle, Pencil, Trash2 } from 'lucide-react';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+interface Article {
+  id: number;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  status: string;
+  publishedAt: string | null;
+  createdAt: string;
+  authorName: string | null;
+  authorEmail: string | null;
+}
+
+export default function ArticlesPage() {
+  const router = useRouter();
+  const { data: articles, mutate } = useSWR<Article[]>('/api/articles', fetcher);
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Are you sure you want to delete this article?')) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/articles/${id}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to delete article');
+      }
+
+      mutate();
+    } catch (error) {
+      console.error('Error deleting article:', error);
+      alert('Failed to delete article');
+    }
+  };
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return 'N/A';
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-lg lg:text-2xl font-medium">Articles</h1>
+        <Button onClick={() => router.push('/dashboard/articles/new')}>
+          <PlusCircle className="mr-2 h-4 w-4" />
+          New Article
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>All Articles</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!articles ? (
+            <p className="text-muted-foreground">Loading...</p>
+          ) : articles.length === 0 ? (
+            <p className="text-muted-foreground">No articles yet.</p>
+          ) : (
+            <div className="space-y-4">
+              {articles.map((article) => (
+                <div
+                  key={article.id}
+                  className="flex items-start justify-between p-4 border rounded-lg"
+                >
+                  <div className="flex-1">
+                    <Link
+                      href={`/dashboard/articles/${article.id}`}
+                      className="text-lg font-medium hover:underline"
+                    >
+                      {article.title}
+                    </Link>
+                    {article.excerpt && (
+                      <p className="text-sm text-muted-foreground mt-1">
+                        {article.excerpt}
+                      </p>
+                    )}
+                    <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
+                      <span className="capitalize">{article.status}</span>
+                      <span>•</span>
+                      <span>
+                        {article.status === 'published'
+                          ? `Published ${formatDate(article.publishedAt)}`
+                          : `Created ${formatDate(article.createdAt)}`}
+                      </span>
+                      <span>•</span>
+                      <span>By {article.authorName || article.authorEmail}</span>
+                    </div>
+                  </div>
+                  <div className="flex gap-2 ml-4">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        router.push(`/dashboard/articles/${article.id}/edit`)
+                      }
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleDelete(article.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/api/articles/[id]/route.ts
+++ b/app/api/articles/[id]/route.ts
@@ -1,0 +1,88 @@
+import {
+  getArticleById,
+  updateArticle,
+  deleteArticle,
+  getUser,
+} from '@/lib/db/queries';
+import { NextRequest } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const article = await getArticleById(parseInt(id));
+
+  if (!article) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  return Response.json(article);
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser();
+
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const article = await getArticleById(parseInt(id));
+
+  if (!article) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  if (article.authorId !== user.id && user.role !== 'admin') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { title, slug, content, excerpt, status } = body;
+
+  const updateData: any = {};
+  if (title) updateData.title = title;
+  if (slug) updateData.slug = slug;
+  if (content) updateData.content = content;
+  if (excerpt !== undefined) updateData.excerpt = excerpt;
+  if (status) {
+    updateData.status = status;
+    if (status === 'published' && !article.publishedAt) {
+      updateData.publishedAt = new Date();
+    }
+  }
+
+  await updateArticle(parseInt(id), updateData);
+
+  return Response.json({ success: true });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser();
+
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const article = await getArticleById(parseInt(id));
+
+  if (!article) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  if (article.authorId !== user.id && user.role !== 'admin') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  await deleteArticle(parseInt(id));
+
+  return Response.json({ success: true });
+}

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,0 +1,37 @@
+import { getArticles, createArticle, getUser } from '@/lib/db/queries';
+import { NextRequest } from 'next/server';
+
+export async function GET() {
+  const articles = await getArticles();
+  return Response.json(articles);
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getUser();
+
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { title, slug, content, excerpt, status } = body;
+
+  if (!title || !slug || !content) {
+    return Response.json(
+      { error: 'Title, slug, and content are required' },
+      { status: 400 }
+    );
+  }
+
+  const article = await createArticle({
+    title,
+    slug,
+    content,
+    excerpt: excerpt || null,
+    authorId: user.id,
+    status: status || 'draft',
+    publishedAt: status === 'published' ? new Date() : null,
+  });
+
+  return Response.json(article, { status: 201 });
+}

--- a/components/article-form.tsx
+++ b/components/article-form.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface ArticleFormProps {
+  article?: {
+    id: number;
+    title: string;
+    slug: string;
+    content: string;
+    excerpt: string | null;
+    status: string;
+  };
+}
+
+export function ArticleForm({ article }: ArticleFormProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    title: article?.title || '',
+    slug: article?.slug || '',
+    content: article?.content || '',
+    excerpt: article?.excerpt || '',
+    status: article?.status || 'draft',
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    try {
+      const url = article
+        ? `/api/articles/${article.id}`
+        : '/api/articles';
+      const method = article ? 'PATCH' : 'POST';
+
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to save article');
+      }
+
+      router.push('/dashboard/articles');
+      router.refresh();
+    } catch (error) {
+      console.error('Error saving article:', error);
+      alert('Failed to save article');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleTitleChange = (title: string) => {
+    setFormData({ ...formData, title });
+    if (!article) {
+      const slug = title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '');
+      setFormData((prev) => ({ ...prev, title, slug }));
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{article ? 'Edit Article' : 'Create Article'}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={formData.title}
+              onChange={(e) => handleTitleChange(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="slug">Slug</Label>
+            <Input
+              id="slug"
+              value={formData.slug}
+              onChange={(e) =>
+                setFormData({ ...formData, slug: e.target.value })
+              }
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="excerpt">Excerpt</Label>
+            <Textarea
+              id="excerpt"
+              value={formData.excerpt}
+              onChange={(e) =>
+                setFormData({ ...formData, excerpt: e.target.value })
+              }
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="content">Content</Label>
+            <Textarea
+              id="content"
+              value={formData.content}
+              onChange={(e) =>
+                setFormData({ ...formData, content: e.target.value })
+              }
+              rows={12}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="status">Status</Label>
+            <select
+              id="status"
+              value={formData.status}
+              onChange={(e) =>
+                setFormData({ ...formData, status: e.target.value })
+              }
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] md:text-sm dark:bg-input/30"
+            >
+              <option value="draft">Draft</option>
+              <option value="published">Published</option>
+            </select>
+          </div>
+
+          <div className="flex gap-2">
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? 'Saving...' : article ? 'Update' : 'Create'}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => router.push('/dashboard/articles')}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex min-h-[60px] w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/lib/db/migrations/0001_fancy_patriot.sql
+++ b/lib/db/migrations/0001_fancy_patriot.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "articles" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"slug" varchar(255) NOT NULL,
+	"content" text NOT NULL,
+	"excerpt" text,
+	"author_id" integer NOT NULL,
+	"status" varchar(20) DEFAULT 'draft' NOT NULL,
+	"published_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "articles_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "articles" ADD CONSTRAINT "articles_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/lib/db/migrations/meta/0001_snapshot.json
+++ b/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,505 @@
+{
+  "id": "8d23e550-0378-43c0-a4df-0cac52ca9420",
+  "prevId": "261fd993-fb2c-43e7-89d6-cd58786c5f58",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_logs_team_id_teams_id_fk": {
+          "name": "activity_logs_team_id_teams_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_user_id_users_id_fk": {
+          "name": "activity_logs_user_id_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "articles_author_id_users_id_fk": {
+          "name": "articles_author_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "articles_slug_unique": {
+          "name": "articles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_team_id_teams_id_fk": {
+          "name": "invitations_team_id_teams_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_stripe_customer_id_unique": {
+          "name": "teams_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "teams_stripe_subscription_id_unique": {
+          "name": "teams_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1726443359662,
       "tag": "0000_soft_the_anarchist",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1759573018873,
+      "tag": "0001_fancy_patriot",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -54,6 +54,21 @@ export const activityLogs = pgTable('activity_logs', {
   ipAddress: varchar('ip_address', { length: 45 }),
 });
 
+export const articles = pgTable('articles', {
+  id: serial('id').primaryKey(),
+  title: varchar('title', { length: 255 }).notNull(),
+  slug: varchar('slug', { length: 255 }).notNull().unique(),
+  content: text('content').notNull(),
+  excerpt: text('excerpt'),
+  authorId: integer('author_id')
+    .notNull()
+    .references(() => users.id),
+  status: varchar('status', { length: 20 }).notNull().default('draft'),
+  publishedAt: timestamp('published_at'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});
+
 export const invitations = pgTable('invitations', {
   id: serial('id').primaryKey(),
   teamId: integer('team_id')
@@ -77,6 +92,7 @@ export const teamsRelations = relations(teams, ({ many }) => ({
 export const usersRelations = relations(users, ({ many }) => ({
   teamMembers: many(teamMembers),
   invitationsSent: many(invitations),
+  articles: many(articles),
 }));
 
 export const invitationsRelations = relations(invitations, ({ one }) => ({
@@ -112,6 +128,13 @@ export const activityLogsRelations = relations(activityLogs, ({ one }) => ({
   }),
 }));
 
+export const articlesRelations = relations(articles, ({ one }) => ({
+  author: one(users, {
+    fields: [articles.authorId],
+    references: [users.id],
+  }),
+}));
+
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type Team = typeof teams.$inferSelect;
@@ -122,10 +145,15 @@ export type ActivityLog = typeof activityLogs.$inferSelect;
 export type NewActivityLog = typeof activityLogs.$inferInsert;
 export type Invitation = typeof invitations.$inferSelect;
 export type NewInvitation = typeof invitations.$inferInsert;
+export type Article = typeof articles.$inferSelect;
+export type NewArticle = typeof articles.$inferInsert;
 export type TeamDataWithMembers = Team & {
   teamMembers: (TeamMember & {
     user: Pick<User, 'id' | 'name' | 'email'>;
   })[];
+};
+export type ArticleWithAuthor = Article & {
+  author: Pick<User, 'id' | 'name' | 'email'>;
 };
 
 export enum ActivityType {


### PR DESCRIPTION
# prompt

```
記事管理機能を追加してください。
```

以下、日本語訳です:

---

# コメント

このプルリクエストは、ダッシュボード内で記事を管理するための完全なCRUDシステムを導入します。バックエンドAPIルート、データベーススキーマ/マイグレーション、そして記事の一覧表示、作成、編集、閲覧、削除のためのフロントエンドページ/コンポーネントが含まれています。変更はデータベースのセットアップ、サーバーサイドのAPIロジック、クライアントサイドのUI/UXにまたがり、認証されたユーザーが自分の記事を作成、更新、削除できるようにし、管理者権限もサポートしています。

**データベースとバックエンドAPI**

* 記事の保存をサポートするため、`articles`テーブルと関連マイグレーションを追加しました。タイトル、スラッグ、コンテンツ、抜粋、著者、ステータス、タイムスタンプ、および一意制約のフィールドを含みます。[[[1]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-830d4aa0b2acb039e07c2c35af5399af0feab5304af38208b3bc17d0ba501e21R1-R15) [[[2]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-74fd593a5a80b2194712ee9d4571e67a7e254bc35c677fa90adc6218938ea6aaR57-R71)
* `lib/db/queries.ts`に記事関連のクエリを実装しました。一覧表示、取得(IDまたはスラッグ)、作成、更新、削除のための関数を含み、著者の詳細情報との適切な結合を行います。[[[1]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-7ab478d8968ac35746c189af69f710ec26bcc24ce97bbf672718695a8d5735c7L3-R6) [[[2]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-7ab478d8968ac35746c189af69f710ec26bcc24ce97bbf672718695a8d5735c7R132-R216)
* `app/api/articles/route.ts`と`app/api/articles/[id]/route.ts`にREST APIエンドポイントを追加し、記事の一覧表示、作成、更新、削除を行います。認証および認可チェックも含まれます。([[app/api/articles/route.tsR1-R37](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-4e3e19ce5748dbdef474a2ecce85ddee6f9d9f93822eee4eb52b0a7003a7e1baR1-R37), [[app/api/articles/[id]/route.tsR1-R88](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-a8269d7e5fcd9cdd451912c93b3a8458728faf0bd5170b529ff95ad902795132R1-R88))

**フロントエンドUI/UX**

* ダッシュボードに、全記事の一覧表示、詳細表示、新規記事作成、既存記事編集のためのReactページを作成しました。記事アクション(編集、削除)とナビゲーションのためのUIも含まれます。[[[1]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-6d90f679d66d9a5009711e3d18e5d82b9359e5085e932e17ab7f3ece8439c3fcR1-R139) [[app/(dashboard)/dashboard/articles/[id]/page.tsxR1-R69](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-d95acea9b65cf80fa8d75f3ddfb7eb52827bad1f55a4d9440281f604e0a252ebR1-R69), [[[2]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-2ee8f157ace3c74a32c3e155c62a0f77e35fe4b5980079d208f6e777e6d81649R1-R10) [[app/(dashboard)/dashboard/articles/[id]/edit/page.tsxR1-R32](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-55ec0b7133516b148543dbd5d24b408edef3cf5644418745d38c492db42e097eR1-R32))
* 記事の作成と編集の両方に使用できる再利用可能な`ArticleForm`コンポーネントを追加しました。フォームバリデーション、スラッグの自動生成、ステータス選択機能を備えています。[[[1]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-56edd30ef9d6bf4f8ab2278784125c2e18f16ae0f4def756a4cc92c57e1c3b37R1-R161) [[[2]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-e1d2ad49fd73fb2e929868488702834f446bce9da614987f06cc18192b45b1feR1-R23)

**マイグレーションメタデータ**

* 適切なデータベースバージョン管理のため、新しい記事テーブルのマイグレーションを含むようにマイグレーションジャーナルを更新しました。

**データベースとORMの統合**
- ORM操作とユーザー-記事の関連付けをサポートするため、`lib/db/schema.ts`に`articles`テーブル定義とリレーションを追加しました。[[[1]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-74fd593a5a80b2194712ee9d4571e67a7e254bc35c677fa90adc6218938ea6aaR57-R71) [[[2]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-74fd593a5a80b2194712ee9d4571e67a7e254bc35c677fa90adc6218938ea6aaR95)

**APIとデータ層**
- `lib/db/queries.ts`に記事用の包括的なクエリ関数を実装し、CRUD操作と著者データの結合を可能にしました。[[[1]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-7ab478d8968ac35746c189af69f710ec26bcc24ce97bbf672718695a8d5735c7L3-R6) [[[2]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-7ab478d8968ac35746c189af69f710ec26bcc24ce97bbf672718695a8d5735c7R132-R216)
- `app/api/articles/route.ts`と`app/api/articles/[id]/route.ts`に、認証と認可ロジックを含む記事用のREST APIエンドポイントを追加しました。([[app/api/articles/route.tsR1-R37](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-4e3e19ce5748dbdef474a2ecce85ddee6f9d9f93822eee4eb52b0a7003a7e1baR1-R37), [[app/api/articles/[id]/route.tsR1-R88](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-a8269d7e5fcd9cdd451912c93b3a8458728faf0bd5170b529ff95ad902795132R1-R88))

**フロントエンドコンポーネントとページ**
- 記事の一覧表示、閲覧、作成、編集のためのダッシュボードページを開発しました。統合されたアクションとナビゲーション機能付きです。[[[1]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-6d90f679d66d9a5009711e3d18e5d82b9359e5085e932e17ab7f3ece8439c3fcR1-R139) [[app/(dashboard)/dashboard/articles/[id]/page.tsxR1-R69](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-d95acea9b65cf80fa8d75f3ddfb7eb52827bad1f55a4d9440281f604e0a252ebR1-R69), [[[2]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-2ee8f157ace3c74a32c3e155c62a0f77e35fe4b5980079d208f6e777e6d81649R1-R10) [[app/(dashboard)/dashboard/articles/[id]/edit/page.tsxR1-R32](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-55ec0b7133516b148543dbd5d24b408edef3cf5644418745d38c492db42e097eR1-R32))
- 記事管理のための`ArticleForm`とサポートUIコンポーネントを作成しました。入力バリデーションとステータス処理が含まれます。[[[1]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-56edd30ef9d6bf4f8ab2278784125c2e18f16ae0f4def756a4cc92c57e1c3b37R1-R161) [[[2]](https://claude.ai/chat/04c681ea-e5f0-4af9-b426-030919009460)](diffhunk://#diff-e1d2ad49fd73fb2e929868488702834f446bce9da614987f06cc18192b45b1feR1-R23)

**マイグレーション追跡**
- 新しい記事テーブルのマイグレーションを反映するようにマイグレーションジャーナルを更新しました。