### PR TITLE
記事管理 impl claude prompt roleplay

### DIFF
--- a/app/(dashboard)/dashboard/articles/page.tsx
+++ b/app/(dashboard)/dashboard/articles/page.tsx
@@ -1,0 +1,363 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription
+} from '@/components/ui/card';
+import { Article } from '@/lib/db/schema';
+import useSWR, { mutate } from 'swr';
+import { Suspense, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter
+} from '@/components/ui/dialog';
+import { PlusCircle, Pencil, Trash2, FileText } from 'lucide-react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+function ArticlesSkeleton() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Articles</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="animate-pulse space-y-4">
+          <div className="h-12 bg-muted rounded"></div>
+          <div className="h-12 bg-muted rounded"></div>
+          <div className="h-12 bg-muted rounded"></div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface ArticleFormData {
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string;
+  status: 'draft' | 'published';
+}
+
+function ArticleDialog({
+  article,
+  onSuccess
+}: {
+  article?: Article;
+  onSuccess: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState<ArticleFormData>({
+    title: article?.title || '',
+    slug: article?.slug || '',
+    content: article?.content || '',
+    excerpt: article?.excerpt || '',
+    status: (article?.status as 'draft' | 'published') || 'draft'
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const url = article
+        ? `/api/articles/${article.id}`
+        : '/api/articles';
+      const method = article ? 'PUT' : 'POST';
+
+      const response = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to save article');
+      }
+
+      mutate('/api/articles');
+      setOpen(false);
+      onSuccess();
+    } catch (error) {
+      console.error('Error saving article:', error);
+      alert('Failed to save article');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const generateSlug = (title: string) => {
+    return title
+      .toLowerCase()
+      .replace(/[^\w\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/--+/g, '-')
+      .trim();
+  };
+
+  const handleTitleChange = (title: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      title,
+      slug: generateSlug(title)
+    }));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {article ? (
+          <Button variant="ghost" size="sm">
+            <Pencil className="h-4 w-4" />
+          </Button>
+        ) : (
+          <Button>
+            <PlusCircle className="mr-2 h-4 w-4" />
+            New Article
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {article ? 'Edit Article' : 'Create New Article'}
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={formData.title}
+              onChange={(e) => handleTitleChange(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="slug">Slug</Label>
+            <Input
+              id="slug"
+              value={formData.slug}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, slug: e.target.value }))
+              }
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="excerpt">Excerpt</Label>
+            <Textarea
+              id="excerpt"
+              value={formData.excerpt}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, excerpt: e.target.value }))
+              }
+              rows={3}
+            />
+          </div>
+          <div>
+            <Label htmlFor="content">Content</Label>
+            <Textarea
+              id="content"
+              value={formData.content}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, content: e.target.value }))
+              }
+              required
+              rows={10}
+            />
+          </div>
+          <div>
+            <Label htmlFor="status">Status</Label>
+            <Select
+              value={formData.status}
+              onValueChange={(value: 'draft' | 'published') =>
+                setFormData((prev) => ({ ...prev, status: value }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="draft">Draft</SelectItem>
+                <SelectItem value="published">Published</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Saving...' : article ? 'Update' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ArticlesList() {
+  const { data: articles, error } = useSWR<Article[]>('/api/articles', fetcher);
+
+  const deleteArticle = async (id: number) => {
+    if (!confirm('Are you sure you want to delete this article?')) return;
+
+    try {
+      const response = await fetch(`/api/articles/${id}`, {
+        method: 'DELETE'
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to delete article');
+      }
+
+      mutate('/api/articles');
+    } catch (error) {
+      console.error('Error deleting article:', error);
+      alert('Failed to delete article');
+    }
+  };
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Articles</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">Failed to load articles</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!articles) {
+    return <ArticlesSkeleton />;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Articles</CardTitle>
+            <CardDescription>
+              Manage your team&apos;s articles
+            </CardDescription>
+          </div>
+          <ArticleDialog onSuccess={() => mutate('/api/articles')} />
+        </div>
+      </CardHeader>
+      <CardContent>
+        {articles.length === 0 ? (
+          <div className="text-center py-12">
+            <FileText className="mx-auto h-12 w-12 text-muted-foreground" />
+            <h3 className="mt-4 text-lg font-semibold">No articles yet</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Get started by creating your first article
+            </p>
+            <div className="mt-6">
+              <ArticleDialog onSuccess={() => mutate('/api/articles')} />
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Title</TableHead>
+                  <TableHead>Slug</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {articles.map((article) => (
+                  <TableRow key={article.id}>
+                    <TableCell className="font-medium">
+                      {article.title}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {article.slug}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={
+                          article.status === 'published'
+                            ? 'default'
+                            : 'secondary'
+                        }
+                      >
+                        {article.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {new Date(article.createdAt).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <ArticleDialog
+                          article={article}
+                          onSuccess={() => mutate('/api/articles')}
+                        />
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => deleteArticle(article.id)}
+                        >
+                          <Trash2 className="h-4 w-4 text-red-500" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function ArticlesPage() {
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <h1 className="text-lg lg:text-2xl font-medium mb-6">
+        Article Management
+      </h1>
+      <Suspense fallback={<ArticlesSkeleton />}>
+        <ArticlesList />
+      </Suspense>
+    </section>
+  );
+}

--- a/app/(dashboard)/dashboard/layout.tsx
+++ b/app/(dashboard)/dashboard/layout.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import { Users, Settings, Shield, Activity, Menu } from 'lucide-react';
+import { Users, Settings, Shield, Activity, Menu, FileText } from 'lucide-react';
 
 export default function DashboardLayout({
   children
@@ -18,7 +18,8 @@ export default function DashboardLayout({
     { href: '/dashboard', icon: Users, label: 'Team' },
     { href: '/dashboard/general', icon: Settings, label: 'General' },
     { href: '/dashboard/activity', icon: Activity, label: 'Activity' },
-    { href: '/dashboard/security', icon: Shield, label: 'Security' }
+    { href: '/dashboard/security', icon: Shield, label: 'Security' },
+    { href: '/dashboard/articles', icon: FileText, label: 'Articles' }
   ];
 
   return (

--- a/app/api/articles/[id]/route.ts
+++ b/app/api/articles/[id]/route.ts
@@ -1,0 +1,118 @@
+import { db } from '@/lib/db/drizzle';
+import { articles } from '@/lib/db/schema';
+import { getUser, getTeamForUser } from '@/lib/db/queries';
+import { eq, and } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const team = await getTeamForUser();
+  if (!team) {
+    return Response.json({ error: 'Team not found' }, { status: 404 });
+  }
+
+  const { id } = await params;
+  const article = await db
+    .select()
+    .from(articles)
+    .where(and(eq(articles.id, parseInt(id)), eq(articles.teamId, team.id)))
+    .limit(1);
+
+  if (article.length === 0) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  return Response.json(article[0]);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const team = await getTeamForUser();
+  if (!team) {
+    return Response.json({ error: 'Team not found' }, { status: 404 });
+  }
+
+  const { id } = await params;
+  const body = await request.json();
+  const { title, slug, content, excerpt, status } = body;
+
+  const existingArticle = await db
+    .select()
+    .from(articles)
+    .where(and(eq(articles.id, parseInt(id)), eq(articles.teamId, team.id)))
+    .limit(1);
+
+  if (existingArticle.length === 0) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  const updateData: any = {
+    updatedAt: new Date(),
+  };
+
+  if (title !== undefined) updateData.title = title;
+  if (slug !== undefined) updateData.slug = slug;
+  if (content !== undefined) updateData.content = content;
+  if (excerpt !== undefined) updateData.excerpt = excerpt;
+  if (status !== undefined) {
+    updateData.status = status;
+    if (status === 'published' && !existingArticle[0].publishedAt) {
+      updateData.publishedAt = new Date();
+    }
+  }
+
+  const updatedArticle = await db
+    .update(articles)
+    .set(updateData)
+    .where(and(eq(articles.id, parseInt(id)), eq(articles.teamId, team.id)))
+    .returning();
+
+  return Response.json(updatedArticle[0]);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const team = await getTeamForUser();
+  if (!team) {
+    return Response.json({ error: 'Team not found' }, { status: 404 });
+  }
+
+  const { id } = await params;
+
+  const existingArticle = await db
+    .select()
+    .from(articles)
+    .where(and(eq(articles.id, parseInt(id)), eq(articles.teamId, team.id)))
+    .limit(1);
+
+  if (existingArticle.length === 0) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  await db
+    .delete(articles)
+    .where(and(eq(articles.id, parseInt(id)), eq(articles.teamId, team.id)));
+
+  return Response.json({ message: 'Article deleted successfully' });
+}

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,0 +1,63 @@
+import { db } from '@/lib/db/drizzle';
+import { articles } from '@/lib/db/schema';
+import { getUser, getTeamForUser } from '@/lib/db/queries';
+import { eq, desc } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+
+export async function GET() {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const team = await getTeamForUser();
+  if (!team) {
+    return Response.json({ error: 'Team not found' }, { status: 404 });
+  }
+
+  const articlesList = await db
+    .select()
+    .from(articles)
+    .where(eq(articles.teamId, team.id))
+    .orderBy(desc(articles.createdAt));
+
+  return Response.json(articlesList);
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const team = await getTeamForUser();
+  if (!team) {
+    return Response.json({ error: 'Team not found' }, { status: 404 });
+  }
+
+  const body = await request.json();
+  const { title, slug, content, excerpt, status } = body;
+
+  if (!title || !slug || !content) {
+    return Response.json(
+      { error: 'Title, slug, and content are required' },
+      { status: 400 }
+    );
+  }
+
+  const newArticle = await db
+    .insert(articles)
+    .values({
+      title,
+      slug,
+      content,
+      excerpt: excerpt || null,
+      status: status || 'draft',
+      authorId: user.id,
+      teamId: team.id,
+      publishedAt: status === 'published' ? new Date() : null,
+    })
+    .returning();
+
+  return Response.json(newArticle[0], { status: 201 });
+}

--- a/lib/db/migrations/0001_dry_layla_miller.sql
+++ b/lib/db/migrations/0001_dry_layla_miller.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "articles" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"slug" varchar(255) NOT NULL,
+	"content" text NOT NULL,
+	"excerpt" text,
+	"status" varchar(20) DEFAULT 'draft' NOT NULL,
+	"author_id" integer NOT NULL,
+	"team_id" integer NOT NULL,
+	"published_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "articles_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "articles" ADD CONSTRAINT "articles_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "articles" ADD CONSTRAINT "articles_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;

--- a/lib/db/migrations/meta/0001_snapshot.json
+++ b/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,524 @@
+{
+  "id": "5987f67f-4d1f-492d-a8ae-7a342908d7a7",
+  "prevId": "261fd993-fb2c-43e7-89d6-cd58786c5f58",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_logs_team_id_teams_id_fk": {
+          "name": "activity_logs_team_id_teams_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_user_id_users_id_fk": {
+          "name": "activity_logs_user_id_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "articles_author_id_users_id_fk": {
+          "name": "articles_author_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "articles_team_id_teams_id_fk": {
+          "name": "articles_team_id_teams_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "articles_slug_unique": {
+          "name": "articles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_team_id_teams_id_fk": {
+          "name": "invitations_team_id_teams_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_stripe_customer_id_unique": {
+          "name": "teams_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "teams_stripe_subscription_id_unique": {
+          "name": "teams_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1726443359662,
       "tag": "0000_soft_the_anarchist",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1759573501571,
+      "tag": "0001_dry_layla_miller",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -68,15 +68,35 @@ export const invitations = pgTable('invitations', {
   status: varchar('status', { length: 20 }).notNull().default('pending'),
 });
 
+export const articles = pgTable('articles', {
+  id: serial('id').primaryKey(),
+  title: varchar('title', { length: 255 }).notNull(),
+  slug: varchar('slug', { length: 255 }).notNull().unique(),
+  content: text('content').notNull(),
+  excerpt: text('excerpt'),
+  status: varchar('status', { length: 20 }).notNull().default('draft'),
+  authorId: integer('author_id')
+    .notNull()
+    .references(() => users.id),
+  teamId: integer('team_id')
+    .notNull()
+    .references(() => teams.id),
+  publishedAt: timestamp('published_at'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});
+
 export const teamsRelations = relations(teams, ({ many }) => ({
   teamMembers: many(teamMembers),
   activityLogs: many(activityLogs),
   invitations: many(invitations),
+  articles: many(articles),
 }));
 
 export const usersRelations = relations(users, ({ many }) => ({
   teamMembers: many(teamMembers),
   invitationsSent: many(invitations),
+  articles: many(articles),
 }));
 
 export const invitationsRelations = relations(invitations, ({ one }) => ({
@@ -112,6 +132,17 @@ export const activityLogsRelations = relations(activityLogs, ({ one }) => ({
   }),
 }));
 
+export const articlesRelations = relations(articles, ({ one }) => ({
+  author: one(users, {
+    fields: [articles.authorId],
+    references: [users.id],
+  }),
+  team: one(teams, {
+    fields: [articles.teamId],
+    references: [teams.id],
+  }),
+}));
+
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type Team = typeof teams.$inferSelect;
@@ -122,6 +153,8 @@ export type ActivityLog = typeof activityLogs.$inferSelect;
 export type NewActivityLog = typeof activityLogs.$inferInsert;
 export type Invitation = typeof invitations.$inferSelect;
 export type NewInvitation = typeof invitations.$inferInsert;
+export type Article = typeof articles.$inferSelect;
+export type NewArticle = typeof articles.$inferInsert;
 export type TeamDataWithMembers = Team & {
   teamMembers: (TeamMember & {
     user: Pick<User, 'id' | 'name' | 'email'>;


### PR DESCRIPTION
このプルリクエストは、ダッシュボードに新しい記事管理機能を導入し、一貫したカラートークンと背景クラスを使用するようUIを更新し、コントリビューター向けの包括的なリポジトリガイドラインドキュメントを追加するものです。最も重要な変更点は、記事のCRUDインターフェースの追加、ダッシュボード全体のUI一貫性の向上、そしてプロジェクト構造とワークフローのベストプラクティスの追加です。

**新機能**

* データ取得にSWR、ダイアログ、テーブル、フォーム用のUIコンポーネントを活用した、作成、編集、削除機能を備えたフル機能の記事管理ページ(`app/(dashboard)/dashboard/articles/page.tsx`)を追加しました。
* ダッシュボードのサイドバーを更新し、適切なアイコンとともに「Articles」ナビゲーション項目を追加することで、新機能へのアクセスを容易にしました。[[[1]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-c96ef23d00d5a761faacc4f891cf10ab1d90dce9577cb28619589927a1466ee2L7-R7) [[[2]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-c96ef23d00d5a761faacc4f891cf10ab1d90dce9577cb28619589927a1466ee2L21-R28)

**UIの一貫性とテーマ設定**

* ダッシュボードのページとコンポーネント全体で、ハードコードされたカラークラス(例:`text-gray-900`、`bg-gray-200`)を、`text-foreground`、`bg-muted`、`border-border`などのセマンティックトークンに置き換え、テーマ設定のサポートと保守性の向上を実現しました。[[[1]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-e44961c7ff503b6842924e91ed080450fbcedd34549a676c1b16fba8d6e848d3L76-R76) [[[2]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-e44961c7ff503b6842924e91ed080450fbcedd34549a676c1b16fba8d6e848d3L98-R102) [[[3]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-e44961c7ff503b6842924e91ed080450fbcedd34549a676c1b16fba8d6e848d3L113-R116) [[[4]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-e966f3dbf6da161975b2e9b83b4ee1c9cf7d4617afce3434b387f04498539519L83-R83) [[[5]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-50f759f838439527a05eda1b4478268096a334cb4d5104cf7fb5311dd6e70938L84-R87) [[[6]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-bca02cb6454ea6bd4105f9519d9d42137b0331c1d64967cc894963e1709d070dL38-R38) [[[7]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-bca02cb6454ea6bd4105f9519d9d42137b0331c1d64967cc894963e1709d070dL123-R123) [[[8]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-cb393df2f4d5792ea9bf8504a3f047d06cb29b7afb51da902154ce95da1ac85eL37-R38) [[[9]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-cb393df2f4d5792ea9bf8504a3f047d06cb29b7afb51da902154ce95da1ac85eL83-R91) [[[10]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-c96ef23d00d5a761faacc4f891cf10ab1d90dce9577cb28619589927a1466ee2L44-R45) [[[11]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-c96ef23d00d5a761faacc4f891cf10ab1d90dce9577cb28619589927a1466ee2L55-R56)
* ライトモードとダークモード間の簡単な切り替えを可能にする`ThemeToggle`コンポーネントをダッシュボードヘッダーに追加しました。[[[1]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-cb393df2f4d5792ea9bf8504a3f047d06cb29b7afb51da902154ce95da1ac85eR18) [[[2]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-cb393df2f4d5792ea9bf8504a3f047d06cb29b7afb51da902154ce95da1ac85eL83-R91)

**ドキュメントとガイドライン**

* コントリビューター向けに、プロジェクト構造、コーディング標準、コミット規約、テスト、セキュリティ実践をカバーする詳細なリポジトリガイドラインドキュメント`AGENTS.md`を追加しました。