### PR TITLE
【第5回】記事管理 impl claude prompt roleplay+fewshot

### DIFF
--- a/app/(dashboard)/dashboard/articles/actions.ts
+++ b/app/(dashboard)/dashboard/articles/actions.ts
@@ -1,0 +1,138 @@
+'use server';
+
+import { z } from 'zod';
+import { db } from '@/lib/db/drizzle';
+import { articles, activityLogs, ActivityType } from '@/lib/db/schema';
+import { getUserWithTeam } from '@/lib/db/queries';
+import { validatedActionWithUser } from '@/lib/auth/middleware';
+import { eq, and } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+
+async function logActivity(
+  teamId: number | null | undefined,
+  userId: number,
+  type: ActivityType
+) {
+  if (teamId === null || teamId === undefined) {
+    return;
+  }
+  await db.insert(activityLogs).values({
+    teamId,
+    userId,
+    action: type,
+    ipAddress: '',
+  });
+}
+
+const createArticleSchema = z.object({
+  title: z.string().min(1, 'Title is required').max(255),
+  content: z.string().optional(),
+  status: z.enum(['draft', 'published']).default('draft'),
+});
+
+export const createArticle = validatedActionWithUser(
+  createArticleSchema,
+  async (data, _, user) => {
+    const { title, content, status } = data;
+    const userWithTeam = await getUserWithTeam(user.id);
+
+    if (!userWithTeam?.teamId) {
+      return { error: 'User is not part of a team' };
+    }
+
+    const [newArticle] = await db
+      .insert(articles)
+      .values({
+        teamId: userWithTeam.teamId,
+        userId: user.id,
+        title,
+        content: content || '',
+        status,
+      })
+      .returning();
+
+    await logActivity(userWithTeam.teamId, user.id, ActivityType.CREATE_ARTICLE);
+
+    revalidatePath('/dashboard/articles');
+    return { success: 'Article created successfully', article: newArticle };
+  }
+);
+
+const updateArticleSchema = z.object({
+  id: z.number(),
+  title: z.string().min(1, 'Title is required').max(255),
+  content: z.string().optional(),
+  status: z.enum(['draft', 'published']),
+});
+
+export const updateArticle = validatedActionWithUser(
+  updateArticleSchema,
+  async (data, _, user) => {
+    const { id, title, content, status } = data;
+    const userWithTeam = await getUserWithTeam(user.id);
+
+    if (!userWithTeam?.teamId) {
+      return { error: 'User is not part of a team' };
+    }
+
+    const [updatedArticle] = await db
+      .update(articles)
+      .set({
+        title,
+        content: content || '',
+        status,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(articles.id, id),
+          eq(articles.teamId, userWithTeam.teamId)
+        )
+      )
+      .returning();
+
+    if (!updatedArticle) {
+      return { error: 'Article not found' };
+    }
+
+    await logActivity(userWithTeam.teamId, user.id, ActivityType.UPDATE_ARTICLE);
+
+    revalidatePath('/dashboard/articles');
+    return { success: 'Article updated successfully', article: updatedArticle };
+  }
+);
+
+const deleteArticleSchema = z.object({
+  id: z.number(),
+});
+
+export const deleteArticle = validatedActionWithUser(
+  deleteArticleSchema,
+  async (data, _, user) => {
+    const { id } = data;
+    const userWithTeam = await getUserWithTeam(user.id);
+
+    if (!userWithTeam?.teamId) {
+      return { error: 'User is not part of a team' };
+    }
+
+    const [deletedArticle] = await db
+      .delete(articles)
+      .where(
+        and(
+          eq(articles.id, id),
+          eq(articles.teamId, userWithTeam.teamId)
+        )
+      )
+      .returning();
+
+    if (!deletedArticle) {
+      return { error: 'Article not found' };
+    }
+
+    await logActivity(userWithTeam.teamId, user.id, ActivityType.DELETE_ARTICLE);
+
+    revalidatePath('/dashboard/articles');
+    return { success: 'Article deleted successfully' };
+  }
+);

--- a/app/(dashboard)/dashboard/articles/page.tsx
+++ b/app/(dashboard)/dashboard/articles/page.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useActionState, useState, useTransition } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Loader2, Plus, Edit, Trash2 } from 'lucide-react';
+import { createArticle, updateArticle, deleteArticle } from './actions';
+import { Article } from '@/lib/db/schema';
+import useSWR from 'swr';
+import { Suspense } from 'react';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+type ActionState = {
+  error?: string;
+  success?: string;
+  article?: Article;
+};
+
+type ArticleFormProps = {
+  state: ActionState;
+  article?: Article;
+  onCancel?: () => void;
+};
+
+function ArticleForm({ state, article, onCancel }: ArticleFormProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = async (formData: FormData) => {
+    startTransition(async () => {
+      if (article) {
+        formData.append('id', article.id.toString());
+        await updateArticle(state, formData);
+      } else {
+        await createArticle(state, formData);
+      }
+      if (onCancel) onCancel();
+    });
+  };
+
+  return (
+    <form action={handleSubmit} className="space-y-4">
+      <div>
+        <Label htmlFor="title" className="mb-2">
+          Title
+        </Label>
+        <Input
+          id="title"
+          name="title"
+          placeholder="Enter article title"
+          defaultValue={article?.title || ''}
+          required
+        />
+      </div>
+      <div>
+        <Label htmlFor="content" className="mb-2">
+          Content
+        </Label>
+        <textarea
+          id="content"
+          name="content"
+          placeholder="Enter article content"
+          defaultValue={article?.content || ''}
+          className="flex min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        />
+      </div>
+      <div>
+        <Label htmlFor="status" className="mb-2">
+          Status
+        </Label>
+        <select
+          id="status"
+          name="status"
+          defaultValue={article?.status || 'draft'}
+          className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs transition-all file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <option value="draft">Draft</option>
+          <option value="published">Published</option>
+        </select>
+      </div>
+      {state.error && (
+        <p className="text-red-500 text-sm">{state.error}</p>
+      )}
+      {state.success && (
+        <p className="text-green-500 text-sm">{state.success}</p>
+      )}
+      <div className="flex gap-2">
+        <Button
+          type="submit"
+          className="bg-orange-500 hover:bg-orange-600 text-white"
+          disabled={isPending}
+        >
+          {isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            article ? 'Update Article' : 'Create Article'
+          )}
+        </Button>
+        {onCancel && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+function ArticleList() {
+  const { data: articles, mutate } = useSWR<Article[]>('/api/articles', fetcher);
+  const [editingArticle, setEditingArticle] = useState<Article | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const [createState, createFormAction] = useActionState<ActionState, FormData>(
+    createArticle,
+    {}
+  );
+  const [updateState, updateFormAction] = useActionState<ActionState, FormData>(
+    updateArticle,
+    {}
+  );
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Are you sure you want to delete this article?')) return;
+
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.append('id', id.toString());
+      const result = await deleteArticle({}, formData);
+      if (result.success) {
+        mutate();
+      }
+    });
+  };
+
+  const handleEdit = (article: Article) => {
+    setEditingArticle(article);
+    setShowCreateForm(false);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingArticle(null);
+    mutate();
+  };
+
+  const handleCancelCreate = () => {
+    setShowCreateForm(false);
+    mutate();
+  };
+
+  if (!articles) {
+    return (
+      <div className="flex justify-center items-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {!showCreateForm && !editingArticle && (
+        <Button
+          onClick={() => setShowCreateForm(true)}
+          className="bg-orange-500 hover:bg-orange-600 text-white"
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          New Article
+        </Button>
+      )}
+
+      {showCreateForm && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Create New Article</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ArticleForm state={createState} onCancel={handleCancelCreate} />
+          </CardContent>
+        </Card>
+      )}
+
+      {editingArticle && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Edit Article</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ArticleForm
+              state={updateState}
+              article={editingArticle}
+              onCancel={handleCancelEdit}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid gap-4">
+        {articles.map((article) => (
+          <Card key={article.id}>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle>{article.title}</CardTitle>
+                <div className="flex gap-2">
+                  <span
+                    className={`px-2 py-1 text-xs rounded ${
+                      article.status === 'published'
+                        ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                        : 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200'
+                    }`}
+                  >
+                    {article.status}
+                  </span>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground mb-4 whitespace-pre-wrap">
+                {article.content}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => handleEdit(article)}
+                  disabled={isPending}
+                >
+                  <Edit className="mr-2 h-4 w-4" />
+                  Edit
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => handleDelete(article.id)}
+                  disabled={isPending}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {articles.length === 0 && !showCreateForm && (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center p-8">
+            <p className="text-muted-foreground mb-4">No articles yet</p>
+            <Button
+              onClick={() => setShowCreateForm(true)}
+              className="bg-orange-500 hover:bg-orange-600 text-white"
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Create Your First Article
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export default function ArticlesPage() {
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <h1 className="text-lg lg:text-2xl font-medium text-foreground mb-6">
+        Article Management
+      </h1>
+
+      <Suspense
+        fallback={
+          <div className="flex justify-center items-center p-8">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        }
+      >
+        <ArticleList />
+      </Suspense>
+    </section>
+  );
+}

--- a/app/api/articles/[id]/route.ts
+++ b/app/api/articles/[id]/route.ts
@@ -1,0 +1,111 @@
+import { db } from '@/lib/db/drizzle';
+import { articles } from '@/lib/db/schema';
+import { getUser, getUserWithTeam } from '@/lib/db/queries';
+import { eq, and } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userWithTeam = await getUserWithTeam(user.id);
+  if (!userWithTeam?.teamId) {
+    return Response.json({ error: 'User is not part of a team' }, { status: 400 });
+  }
+
+  const { id } = await params;
+  const [article] = await db
+    .select()
+    .from(articles)
+    .where(
+      and(
+        eq(articles.id, parseInt(id)),
+        eq(articles.teamId, userWithTeam.teamId)
+      )
+    )
+    .limit(1);
+
+  if (!article) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  return Response.json(article);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userWithTeam = await getUserWithTeam(user.id);
+  if (!userWithTeam?.teamId) {
+    return Response.json({ error: 'User is not part of a team' }, { status: 400 });
+  }
+
+  const { id } = await params;
+  const body = await request.json();
+  const { title, content, status } = body;
+
+  const [updatedArticle] = await db
+    .update(articles)
+    .set({
+      title,
+      content,
+      status,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(articles.id, parseInt(id)),
+        eq(articles.teamId, userWithTeam.teamId)
+      )
+    )
+    .returning();
+
+  if (!updatedArticle) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  return Response.json(updatedArticle);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userWithTeam = await getUserWithTeam(user.id);
+  if (!userWithTeam?.teamId) {
+    return Response.json({ error: 'User is not part of a team' }, { status: 400 });
+  }
+
+  const { id } = await params;
+  const [deletedArticle] = await db
+    .delete(articles)
+    .where(
+      and(
+        eq(articles.id, parseInt(id)),
+        eq(articles.teamId, userWithTeam.teamId)
+      )
+    )
+    .returning();
+
+  if (!deletedArticle) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  return Response.json({ success: true });
+}

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,0 +1,53 @@
+import { db } from '@/lib/db/drizzle';
+import { articles } from '@/lib/db/schema';
+import { getUser, getUserWithTeam } from '@/lib/db/queries';
+import { eq, and, desc } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userWithTeam = await getUserWithTeam(user.id);
+  if (!userWithTeam?.teamId) {
+    return Response.json({ error: 'User is not part of a team' }, { status: 400 });
+  }
+
+  const teamArticles = await db
+    .select()
+    .from(articles)
+    .where(eq(articles.teamId, userWithTeam.teamId))
+    .orderBy(desc(articles.updatedAt));
+
+  return Response.json(teamArticles);
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userWithTeam = await getUserWithTeam(user.id);
+  if (!userWithTeam?.teamId) {
+    return Response.json({ error: 'User is not part of a team' }, { status: 400 });
+  }
+
+  const body = await request.json();
+  const { title, content, status } = body;
+
+  const [newArticle] = await db
+    .insert(articles)
+    .values({
+      teamId: userWithTeam.teamId,
+      userId: user.id,
+      title,
+      content,
+      status: status || 'draft',
+    })
+    .returning();
+
+  return Response.json(newArticle);
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -68,15 +68,32 @@ export const invitations = pgTable('invitations', {
   status: varchar('status', { length: 20 }).notNull().default('pending'),
 });
 
+export const articles = pgTable('articles', {
+  id: serial('id').primaryKey(),
+  teamId: integer('team_id')
+    .notNull()
+    .references(() => teams.id),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id),
+  title: varchar('title', { length: 255 }).notNull(),
+  content: text('content'),
+  status: varchar('status', { length: 20 }).notNull().default('draft'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});
+
 export const teamsRelations = relations(teams, ({ many }) => ({
   teamMembers: many(teamMembers),
   activityLogs: many(activityLogs),
   invitations: many(invitations),
+  articles: many(articles),
 }));
 
 export const usersRelations = relations(users, ({ many }) => ({
   teamMembers: many(teamMembers),
   invitationsSent: many(invitations),
+  articles: many(articles),
 }));
 
 export const invitationsRelations = relations(invitations, ({ one }) => ({
@@ -112,6 +129,17 @@ export const activityLogsRelations = relations(activityLogs, ({ one }) => ({
   }),
 }));
 
+export const articlesRelations = relations(articles, ({ one }) => ({
+  team: one(teams, {
+    fields: [articles.teamId],
+    references: [teams.id],
+  }),
+  user: one(users, {
+    fields: [articles.userId],
+    references: [users.id],
+  }),
+}));
+
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type Team = typeof teams.$inferSelect;
@@ -122,6 +150,8 @@ export type ActivityLog = typeof activityLogs.$inferSelect;
 export type NewActivityLog = typeof activityLogs.$inferInsert;
 export type Invitation = typeof invitations.$inferSelect;
 export type NewInvitation = typeof invitations.$inferInsert;
+export type Article = typeof articles.$inferSelect;
+export type NewArticle = typeof articles.$inferInsert;
 export type TeamDataWithMembers = Team & {
   teamMembers: (TeamMember & {
     user: Pick<User, 'id' | 'name' | 'email'>;
@@ -139,4 +169,7 @@ export enum ActivityType {
   REMOVE_TEAM_MEMBER = 'REMOVE_TEAM_MEMBER',
   INVITE_TEAM_MEMBER = 'INVITE_TEAM_MEMBER',
   ACCEPT_INVITATION = 'ACCEPT_INVITATION',
+  CREATE_ARTICLE = 'CREATE_ARTICLE',
+  UPDATE_ARTICLE = 'UPDATE_ARTICLE',
+  DELETE_ARTICLE = 'DELETE_ARTICLE',
 }


### PR DESCRIPTION
# prompt

```
あなたはNext.js 14とTypeScriptの専門家です。
フルスタック開発の経験が豊富です。

以下は、このプロジェクトの既存コンポーネントの例です：

【例1: app/dashboard/page.tsx】
@app/(dashboard)/dashboard/general/page.tsx 

【例2: components/ui/button.tsx】
@components/ui/button.tsx 
このパターンに従って、記事管理機能を追加してください。
```

# comment

このプルリクエストは、ダッシュボード内のチーム向け記事管理のための完全なCRUD(作成、読取、更新、削除)システムを導入します。データベーススキーマに新しい`articles`テーブルを追加し、記事操作のためのAPIエンドポイントを実装し、記事の作成、編集、閲覧、削除のための完全な機能を備えたクライアントサイドUIを提供します。記事アクションのアクティビティログ機能も統合されています。

**データベーススキーマの変更:**

* スキーマに新しい`articles`テーブルを追加し、`teams`と`users`へのリレーション、および記事のTypeScript型定義を含んでいます。[[[1]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-74fd593a5a80b2194712ee9d4571e67a7e254bc35c677fa90adc6218938ea6aaR71-R96) [[[2]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-74fd593a5a80b2194712ee9d4571e67a7e254bc35c677fa90adc6218938ea6aaR132-R142) [[[3]](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-74fd593a5a80b2194712ee9d4571e67a7e254bc35c677fa90adc6218938ea6aaR153-R154)
* 記事の作成、更新、削除アクションのログ記録をサポートするため、`ActivityType`列挙型を拡張しました。

**APIエンドポイント:**

* チームベースの認可を備えた、GET(一覧と個別)、POST、PUT、DELETE操作をサポートする記事用のREST APIルートを実装しました。(`app/api/articles/route.ts`、`app/api/articles/[id]/route.ts`) ([[app/api/articles/route.tsR1-R53](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-4e3e19ce5748dbdef474a2ecce85ddee6f9d9f93822eee4eb52b0a7003a7e1baR1-R53)、[[app/api/articles/[id]/route.tsR1-R111](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-a8269d7e5fcd9cdd451912c93b3a8458728faf0bd5170b529ff95ad902795132R1-R111))

**サーバーサイドアクション:**

* 入力検証、チームメンバーシップチェック、アクティビティログ機能を含む、記事の作成、更新、削除のためのサーバーアクションを追加しました。(`app/(dashboard)/dashboard/articles/actions.ts`)

**クライアントサイドUI:**

* フォーム、ローディング状態、サーバーアクションおよびAPIエンドポイントとの統合を含む、記事の一覧表示、作成、編集、削除のためのReactベースのUIを備えたダッシュボードページを構築しました。(`app/(dashboard)/dashboard/articles/page.tsx`)