### PR TITLE
記事管理 impl claude prompt roleplay+fewshot+cot

### DIFF
--- a/app/(dashboard)/articles/[id]/edit/page.tsx
+++ b/app/(dashboard)/articles/[id]/edit/page.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import { use } from 'react';
+import { useActionState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Loader2, ArrowLeft } from 'lucide-react';
+import { updateArticle } from '../../actions';
+import Link from 'next/link';
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+type Article = {
+  id: number;
+  userId: number;
+  teamId: number;
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string | null;
+  status: string;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+};
+
+type ArticleData = {
+  article: Article;
+  authorName: string | null;
+  authorEmail: string | null;
+};
+
+type ActionState = {
+  error?: string;
+  success?: string;
+};
+
+function EditForm({
+  articleId,
+  article,
+  state,
+  formAction,
+  isPending,
+}: {
+  articleId: string;
+  article: Article;
+  state: ActionState;
+  formAction: (payload: FormData) => void;
+  isPending: boolean;
+}) {
+  return (
+    <form className="space-y-6" action={formAction}>
+      <input type="hidden" name="id" value={articleId} />
+
+      <div>
+        <Label htmlFor="title" className="mb-2">
+          タイトル <span className="text-red-500">*</span>
+        </Label>
+        <Input
+          id="title"
+          name="title"
+          placeholder="記事のタイトルを入力"
+          defaultValue={article.title}
+          required
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="excerpt" className="mb-2">
+          要約
+        </Label>
+        <Textarea
+          id="excerpt"
+          name="excerpt"
+          placeholder="記事の要約を入力（任意）"
+          rows={3}
+          maxLength={500}
+          defaultValue={article.excerpt || ''}
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          記事一覧に表示される要約文です（最大500文字）
+        </p>
+      </div>
+
+      <div>
+        <Label htmlFor="content" className="mb-2">
+          本文 <span className="text-red-500">*</span>
+        </Label>
+        <Textarea
+          id="content"
+          name="content"
+          placeholder="記事の本文を入力"
+          rows={15}
+          defaultValue={article.content}
+          required
+        />
+      </div>
+
+      <div>
+        <Label className="mb-3 block">
+          ステータス <span className="text-red-500">*</span>
+        </Label>
+        <div className="space-y-2">
+          <div className="flex items-center space-x-2">
+            <input
+              type="radio"
+              id="status-draft"
+              name="status"
+              value="draft"
+              defaultChecked={article.status === 'draft'}
+              className="h-4 w-4"
+            />
+            <Label htmlFor="status-draft" className="font-normal">
+              下書き
+            </Label>
+          </div>
+          <div className="flex items-center space-x-2">
+            <input
+              type="radio"
+              id="status-published"
+              name="status"
+              value="published"
+              defaultChecked={article.status === 'published'}
+              className="h-4 w-4"
+            />
+            <Label htmlFor="status-published" className="font-normal">
+              公開
+            </Label>
+          </div>
+          <div className="flex items-center space-x-2">
+            <input
+              type="radio"
+              id="status-archived"
+              name="status"
+              value="archived"
+              defaultChecked={article.status === 'archived'}
+              className="h-4 w-4"
+            />
+            <Label htmlFor="status-archived" className="font-normal">
+              アーカイブ
+            </Label>
+          </div>
+        </div>
+      </div>
+
+      {state.error && (
+        <div className="p-3 rounded-md bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800">
+          <p className="text-red-600 dark:text-red-400 text-sm">
+            {state.error}
+          </p>
+        </div>
+      )}
+
+      {state.success && (
+        <div className="p-3 rounded-md bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800">
+          <p className="text-green-600 dark:text-green-400 text-sm">
+            {state.success}
+          </p>
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        <Button
+          type="submit"
+          className="bg-orange-500 hover:bg-orange-600 text-white"
+          disabled={isPending}
+        >
+          {isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              更新中...
+            </>
+          ) : (
+            '変更を保存'
+          )}
+        </Button>
+        <Link href={`/articles/${articleId}`}>
+          <Button type="button" variant="outline">
+            キャンセル
+          </Button>
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+export default function EditArticlePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const { data, error, isLoading } = useSWR<ArticleData>(
+    `/api/articles/${id}`,
+    fetcher
+  );
+
+  const [state, formAction, isPending] = useActionState<ActionState, FormData>(
+    updateArticle,
+    {}
+  );
+
+  if (error) {
+    return (
+      <section className="flex-1 p-4 lg:p-8">
+        <div className="mb-6">
+          <Link
+            href="/articles"
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            記事一覧に戻る
+          </Link>
+        </div>
+        <Card>
+          <CardContent className="p-8">
+            <div className="text-red-500">
+              エラーが発生しました: {error.message || '記事の取得に失敗しました'}
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
+
+  if (isLoading || !data) {
+    return (
+      <section className="flex-1 p-4 lg:p-8">
+        <div className="mb-6">
+          <Link
+            href="/articles"
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            記事一覧に戻る
+          </Link>
+        </div>
+        <Card>
+          <CardContent className="p-8">
+            <div className="text-center text-muted-foreground">
+              読み込み中...
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="mb-6">
+        <Link
+          href={`/articles/${id}`}
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          記事詳細に戻る
+        </Link>
+      </div>
+
+      <h1 className="text-lg lg:text-2xl font-medium text-foreground mb-6">
+        記事編集
+      </h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>記事情報</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <EditForm
+            articleId={id}
+            article={data.article}
+            state={state}
+            formAction={formAction}
+            isPending={isPending}
+          />
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/(dashboard)/articles/[id]/page.tsx
+++ b/app/(dashboard)/articles/[id]/page.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { use } from 'react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft, Edit, Trash2, Calendar, User } from 'lucide-react';
+import Link from 'next/link';
+import useSWR from 'swr';
+import { useRouter } from 'next/navigation';
+import { deleteArticle } from '../actions';
+import { useActionState } from 'react';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+type Article = {
+  id: number;
+  userId: number;
+  teamId: number;
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string | null;
+  status: string;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+};
+
+type ArticleData = {
+  article: Article;
+  authorName: string | null;
+  authorEmail: string | null;
+};
+
+function formatDate(dateString: string | null) {
+  if (!dateString) return '-';
+  return new Date(dateString).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles = {
+    draft: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300',
+    published: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+    archived: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300',
+  };
+
+  const labels = {
+    draft: '下書き',
+    published: '公開中',
+    archived: 'アーカイブ',
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+        styles[status as keyof typeof styles] || styles.draft
+      }`}
+    >
+      {labels[status as keyof typeof labels] || status}
+    </span>
+  );
+}
+
+export default function ArticleDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const router = useRouter();
+  const { data, error, isLoading } = useSWR<ArticleData>(
+    `/api/articles/${id}`,
+    fetcher
+  );
+
+  const [deleteState, deleteAction, isDeleting] = useActionState(
+    async (prevState: any, formData: FormData) => {
+      if (
+        !confirm(
+          '本当にこの記事を削除しますか？この操作は取り消せません。'
+        )
+      ) {
+        return prevState;
+      }
+      formData.append('id', id);
+      return deleteArticle(prevState, formData);
+    },
+    {}
+  );
+
+  if (error) {
+    return (
+      <section className="flex-1 p-4 lg:p-8">
+        <div className="mb-6">
+          <Link
+            href="/articles"
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            記事一覧に戻る
+          </Link>
+        </div>
+        <Card>
+          <CardContent className="p-8">
+            <div className="text-red-500">
+              エラーが発生しました: {error.message || '記事の取得に失敗しました'}
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
+
+  if (isLoading || !data) {
+    return (
+      <section className="flex-1 p-4 lg:p-8">
+        <div className="mb-6">
+          <Link
+            href="/articles"
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            記事一覧に戻る
+          </Link>
+        </div>
+        <Card>
+          <CardContent className="p-8">
+            <div className="text-center text-muted-foreground">
+              読み込み中...
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
+
+  const { article, authorName, authorEmail } = data;
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="mb-6">
+        <Link
+          href="/articles"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          記事一覧に戻る
+        </Link>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex justify-between items-start gap-4">
+            <div className="flex-1">
+              <div className="flex items-center gap-3 mb-2">
+                <h1 className="text-2xl lg:text-3xl font-bold text-foreground">
+                  {article.title}
+                </h1>
+                <StatusBadge status={article.status} />
+              </div>
+
+              <div className="flex flex-wrap gap-4 text-sm text-muted-foreground mt-4">
+                <div className="flex items-center gap-1">
+                  <User className="h-4 w-4" />
+                  <span>{authorName || authorEmail}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Calendar className="h-4 w-4" />
+                  <span>作成: {formatDate(article.createdAt)}</span>
+                </div>
+                {article.publishedAt && (
+                  <div className="flex items-center gap-1">
+                    <Calendar className="h-4 w-4" />
+                    <span>公開: {formatDate(article.publishedAt)}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex gap-2">
+              <Link href={`/articles/${id}/edit`}>
+                <Button variant="outline" size="sm">
+                  <Edit className="h-4 w-4" />
+                </Button>
+              </Link>
+              <form action={deleteAction}>
+                <Button
+                  type="submit"
+                  variant="destructive"
+                  size="sm"
+                  disabled={isDeleting}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </form>
+            </div>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-6">
+          {article.excerpt && (
+            <div className="p-4 bg-muted/50 rounded-lg">
+              <p className="text-sm font-medium text-muted-foreground mb-1">
+                要約
+              </p>
+              <p className="text-foreground">{article.excerpt}</p>
+            </div>
+          )}
+
+          <div>
+            <p className="text-sm font-medium text-muted-foreground mb-3">
+              本文
+            </p>
+            <div className="prose dark:prose-invert max-w-none">
+              <div className="whitespace-pre-wrap text-foreground">
+                {article.content}
+              </div>
+            </div>
+          </div>
+
+          <div className="pt-4 border-t text-xs text-muted-foreground">
+            最終更新: {formatDate(article.updatedAt)}
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/(dashboard)/articles/actions.ts
+++ b/app/(dashboard)/articles/actions.ts
@@ -1,0 +1,163 @@
+'use server';
+
+import { z } from 'zod';
+import { db } from '@/lib/db/drizzle';
+import {
+  articles,
+  type NewArticle,
+  ActivityType,
+} from '@/lib/db/schema';
+import { validatedActionWithUser } from '@/lib/auth/middleware';
+import { getUser, getTeamForUser, getArticleById } from '@/lib/db/queries';
+import { redirect } from 'next/navigation';
+import { eq, and, isNull, sql } from 'drizzle-orm';
+
+function generateSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+const createArticleSchema = z.object({
+  title: z.string().min(1, 'タイトルは必須です').max(255),
+  content: z.string().min(1, '本文は必須です'),
+  excerpt: z.string().max(500).optional(),
+  status: z.enum(['draft', 'published', 'archived']).default('draft'),
+});
+
+export const createArticle = validatedActionWithUser(
+  createArticleSchema,
+  async (data, _, user) => {
+    const { title, content, excerpt, status } = data;
+
+    const teamData = await getTeamForUser();
+    if (!teamData) {
+      return { error: 'チームに所属していません' };
+    }
+
+    const slug = generateSlug(title);
+
+    // Check if slug already exists
+    const existingArticle = await db
+      .select()
+      .from(articles)
+      .where(and(eq(articles.slug, slug), isNull(articles.deletedAt)))
+      .limit(1);
+
+    if (existingArticle.length > 0) {
+      return { error: '同じタイトルの記事が既に存在します' };
+    }
+
+    const newArticle: NewArticle = {
+      userId: user.id,
+      teamId: teamData.id,
+      title,
+      slug,
+      content,
+      excerpt: excerpt || null,
+      status,
+      publishedAt: status === 'published' ? new Date() : null,
+    };
+
+    const [createdArticle] = await db
+      .insert(articles)
+      .values(newArticle)
+      .returning();
+
+    if (!createdArticle) {
+      return { error: '記事の作成に失敗しました' };
+    }
+
+    redirect(`/articles/${createdArticle.id}`);
+  }
+);
+
+const updateArticleSchema = z.object({
+  id: z.number(),
+  title: z.string().min(1, 'タイトルは必須です').max(255),
+  content: z.string().min(1, '本文は必須です'),
+  excerpt: z.string().max(500).optional(),
+  status: z.enum(['draft', 'published', 'archived']),
+});
+
+export const updateArticle = validatedActionWithUser(
+  updateArticleSchema,
+  async (data, _, user) => {
+    const { id, title, content, excerpt, status } = data;
+
+    const articleData = await getArticleById(id);
+    if (!articleData) {
+      return { error: '記事が見つかりません' };
+    }
+
+    // Check if user has permission to update
+    if (articleData.article.userId !== user.id) {
+      return { error: '記事を更新する権限がありません' };
+    }
+
+    const slug = generateSlug(title);
+
+    // Check if new slug conflicts with another article
+    if (slug !== articleData.article.slug) {
+      const existingArticle = await db
+        .select()
+        .from(articles)
+        .where(and(eq(articles.slug, slug), isNull(articles.deletedAt)))
+        .limit(1);
+
+      if (existingArticle.length > 0 && existingArticle[0].id !== id) {
+        return { error: '同じタイトルの記事が既に存在します' };
+      }
+    }
+
+    const wasPublished = articleData.article.status === 'published';
+    const isNowPublished = status === 'published';
+
+    await db
+      .update(articles)
+      .set({
+        title,
+        slug,
+        content,
+        excerpt: excerpt || null,
+        status,
+        publishedAt: isNowPublished && !wasPublished ? new Date() : articleData.article.publishedAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(articles.id, id));
+
+    return { success: '記事を更新しました' };
+  }
+);
+
+const deleteArticleSchema = z.object({
+  id: z.number(),
+});
+
+export const deleteArticle = validatedActionWithUser(
+  deleteArticleSchema,
+  async (data, _, user) => {
+    const { id } = data;
+
+    const articleData = await getArticleById(id);
+    if (!articleData) {
+      return { error: '記事が見つかりません' };
+    }
+
+    // Check if user has permission to delete
+    if (articleData.article.userId !== user.id) {
+      return { error: '記事を削除する権限がありません' };
+    }
+
+    // Soft delete
+    await db
+      .update(articles)
+      .set({
+        deletedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .where(eq(articles.id, id));
+
+    redirect('/articles');
+  }
+);

--- a/app/(dashboard)/articles/new/page.tsx
+++ b/app/(dashboard)/articles/new/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useActionState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { RadioGroup } from '@/components/ui/radio-group';
+import { Loader2, ArrowLeft } from 'lucide-react';
+import { createArticle } from '../actions';
+import Link from 'next/link';
+
+type ActionState = {
+  error?: string;
+  success?: string;
+};
+
+export default function NewArticlePage() {
+  const [state, formAction, isPending] = useActionState<ActionState, FormData>(
+    createArticle,
+    {}
+  );
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="mb-6">
+        <Link
+          href="/articles"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          記事一覧に戻る
+        </Link>
+      </div>
+
+      <h1 className="text-lg lg:text-2xl font-medium text-foreground mb-6">
+        新規記事作成
+      </h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>記事情報</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-6" action={formAction}>
+            <div>
+              <Label htmlFor="title" className="mb-2">
+                タイトル <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                id="title"
+                name="title"
+                placeholder="記事のタイトルを入力"
+                required
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="excerpt" className="mb-2">
+                要約
+              </Label>
+              <Textarea
+                id="excerpt"
+                name="excerpt"
+                placeholder="記事の要約を入力（任意）"
+                rows={3}
+                maxLength={500}
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                記事一覧に表示される要約文です（最大500文字）
+              </p>
+            </div>
+
+            <div>
+              <Label htmlFor="content" className="mb-2">
+                本文 <span className="text-red-500">*</span>
+              </Label>
+              <Textarea
+                id="content"
+                name="content"
+                placeholder="記事の本文を入力"
+                rows={15}
+                required
+              />
+            </div>
+
+            <div>
+              <Label className="mb-3 block">
+                ステータス <span className="text-red-500">*</span>
+              </Label>
+              <RadioGroup defaultValue="draft" name="status">
+                <div className="flex items-center space-x-2">
+                  <input
+                    type="radio"
+                    id="status-draft"
+                    name="status"
+                    value="draft"
+                    defaultChecked
+                    className="h-4 w-4"
+                  />
+                  <Label htmlFor="status-draft" className="font-normal">
+                    下書き
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <input
+                    type="radio"
+                    id="status-published"
+                    name="status"
+                    value="published"
+                    className="h-4 w-4"
+                  />
+                  <Label htmlFor="status-published" className="font-normal">
+                    公開
+                  </Label>
+                </div>
+              </RadioGroup>
+            </div>
+
+            {state.error && (
+              <div className="p-3 rounded-md bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800">
+                <p className="text-red-600 dark:text-red-400 text-sm">
+                  {state.error}
+                </p>
+              </div>
+            )}
+
+            {state.success && (
+              <div className="p-3 rounded-md bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800">
+                <p className="text-green-600 dark:text-green-400 text-sm">
+                  {state.success}
+                </p>
+              </div>
+            )}
+
+            <div className="flex gap-3">
+              <Button
+                type="submit"
+                className="bg-orange-500 hover:bg-orange-600 text-white"
+                disabled={isPending}
+              >
+                {isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    作成中...
+                  </>
+                ) : (
+                  '記事を作成'
+                )}
+              </Button>
+              <Link href="/articles">
+                <Button type="button" variant="outline">
+                  キャンセル
+                </Button>
+              </Link>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/(dashboard)/articles/page.tsx
+++ b/app/(dashboard)/articles/page.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Plus, FileText, Calendar, User } from 'lucide-react';
+import Link from 'next/link';
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+type Article = {
+  id: number;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  status: string;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  authorName: string | null;
+  authorEmail: string | null;
+};
+
+function formatDate(dateString: string | null) {
+  if (!dateString) return '-';
+  return new Date(dateString).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles = {
+    draft: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300',
+    published: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+    archived: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300',
+  };
+
+  const labels = {
+    draft: '下書き',
+    published: '公開中',
+    archived: 'アーカイブ',
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+        styles[status as keyof typeof styles] || styles.draft
+      }`}
+    >
+      {labels[status as keyof typeof labels] || status}
+    </span>
+  );
+}
+
+export default function ArticlesPage() {
+  const { data: articles, error, isLoading } = useSWR<Article[]>(
+    '/api/articles',
+    fetcher
+  );
+
+  if (error) {
+    return (
+      <section className="flex-1 p-4 lg:p-8">
+        <div className="text-red-500">
+          エラーが発生しました: {error.message || '記事の取得に失敗しました'}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-lg lg:text-2xl font-medium text-foreground">
+          記事管理
+        </h1>
+        <Link href="/articles/new">
+          <Button className="bg-orange-500 hover:bg-orange-600 text-white">
+            <Plus className="mr-2 h-4 w-4" />
+            新規記事作成
+          </Button>
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <Card>
+          <CardContent className="p-8">
+            <div className="text-center text-muted-foreground">
+              読み込み中...
+            </div>
+          </CardContent>
+        </Card>
+      ) : articles && articles.length > 0 ? (
+        <div className="grid gap-4">
+          {articles.map((article) => (
+            <Link key={article.id} href={`/articles/${article.id}`}>
+              <Card className="hover:shadow-md transition-shadow cursor-pointer">
+                <CardHeader>
+                  <div className="flex justify-between items-start">
+                    <div className="flex-1">
+                      <CardTitle className="text-xl mb-2">
+                        {article.title}
+                      </CardTitle>
+                      {article.excerpt && (
+                        <p className="text-sm text-muted-foreground line-clamp-2">
+                          {article.excerpt}
+                        </p>
+                      )}
+                    </div>
+                    <StatusBadge status={article.status} />
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+                    <div className="flex items-center gap-1">
+                      <User className="h-4 w-4" />
+                      <span>{article.authorName || article.authorEmail}</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Calendar className="h-4 w-4" />
+                      <span>作成: {formatDate(article.createdAt)}</span>
+                    </div>
+                    {article.publishedAt && (
+                      <div className="flex items-center gap-1">
+                        <FileText className="h-4 w-4" />
+                        <span>公開: {formatDate(article.publishedAt)}</span>
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <Card>
+          <CardContent className="p-8">
+            <div className="text-center">
+              <FileText className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
+              <p className="text-muted-foreground mb-4">
+                まだ記事がありません
+              </p>
+              <Link href="/articles/new">
+                <Button className="bg-orange-500 hover:bg-orange-600 text-white">
+                  <Plus className="mr-2 h-4 w-4" />
+                  最初の記事を作成
+                </Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </section>
+  );
+}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { use, useState, Suspense } from 'react';
 import { Button } from '@/components/ui/button';
-import { CircleIcon, Home, LogOut } from 'lucide-react';
+import { CircleIcon, Home, LogOut, FileText } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -64,6 +64,12 @@ function UserMenu() {
           <Link href="/dashboard" className="flex w-full items-center">
             <Home className="mr-2 h-4 w-4" />
             <span>Dashboard</span>
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer">
+          <Link href="/articles" className="flex w-full items-center">
+            <FileText className="mr-2 h-4 w-4" />
+            <span>Articles</span>
           </Link>
         </DropdownMenuItem>
         <form action={handleSignOut} className="w-full">

--- a/app/api/articles/[id]/route.ts
+++ b/app/api/articles/[id]/route.ts
@@ -1,0 +1,35 @@
+import { getArticleById } from '@/lib/db/queries';
+import { NextResponse } from 'next/server';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const articleId = parseInt(id, 10);
+
+    if (isNaN(articleId)) {
+      return NextResponse.json(
+        { error: '無効な記事IDです' },
+        { status: 400 }
+      );
+    }
+
+    const article = await getArticleById(articleId);
+
+    if (!article) {
+      return NextResponse.json(
+        { error: '記事が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(article);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : '記事の取得に失敗しました' },
+      { status: 401 }
+    );
+  }
+}

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,0 +1,14 @@
+import { getArticles } from '@/lib/db/queries';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const articles = await getArticles();
+    return NextResponse.json(articles);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : '記事の取得に失敗しました' },
+      { status: 401 }
+    );
+  }
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive md:text-sm",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/lib/db/migrations/0001_sharp_proemial_gods.sql
+++ b/lib/db/migrations/0001_sharp_proemial_gods.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "articles" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"team_id" integer NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"slug" varchar(255) NOT NULL,
+	"content" text NOT NULL,
+	"excerpt" text,
+	"status" varchar(20) DEFAULT 'draft' NOT NULL,
+	"published_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"deleted_at" timestamp,
+	CONSTRAINT "articles_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "articles" ADD CONSTRAINT "articles_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "articles" ADD CONSTRAINT "articles_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;

--- a/lib/db/migrations/meta/0001_snapshot.json
+++ b/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,530 @@
+{
+  "id": "7deeea44-db90-4180-a8fb-948187807a44",
+  "prevId": "261fd993-fb2c-43e7-89d6-cd58786c5f58",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_logs_team_id_teams_id_fk": {
+          "name": "activity_logs_team_id_teams_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_user_id_users_id_fk": {
+          "name": "activity_logs_user_id_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "articles_user_id_users_id_fk": {
+          "name": "articles_user_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "articles_team_id_teams_id_fk": {
+          "name": "articles_team_id_teams_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "articles_slug_unique": {
+          "name": "articles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_team_id_teams_id_fk": {
+          "name": "invitations_team_id_teams_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_stripe_customer_id_unique": {
+          "name": "teams_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "teams_stripe_subscription_id_unique": {
+          "name": "teams_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1726443359662,
       "tag": "0000_soft_the_anarchist",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1759575567210,
+      "tag": "0001_sharp_proemial_gods",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -54,6 +54,25 @@ export const activityLogs = pgTable('activity_logs', {
   ipAddress: varchar('ip_address', { length: 45 }),
 });
 
+export const articles = pgTable('articles', {
+  id: serial('id').primaryKey(),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id),
+  teamId: integer('team_id')
+    .notNull()
+    .references(() => teams.id),
+  title: varchar('title', { length: 255 }).notNull(),
+  slug: varchar('slug', { length: 255 }).notNull().unique(),
+  content: text('content').notNull(),
+  excerpt: text('excerpt'),
+  status: varchar('status', { length: 20 }).notNull().default('draft'),
+  publishedAt: timestamp('published_at'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  deletedAt: timestamp('deleted_at'),
+});
+
 export const invitations = pgTable('invitations', {
   id: serial('id').primaryKey(),
   teamId: integer('team_id')
@@ -72,11 +91,13 @@ export const teamsRelations = relations(teams, ({ many }) => ({
   teamMembers: many(teamMembers),
   activityLogs: many(activityLogs),
   invitations: many(invitations),
+  articles: many(articles),
 }));
 
 export const usersRelations = relations(users, ({ many }) => ({
   teamMembers: many(teamMembers),
   invitationsSent: many(invitations),
+  articles: many(articles),
 }));
 
 export const invitationsRelations = relations(invitations, ({ one }) => ({
@@ -112,6 +133,17 @@ export const activityLogsRelations = relations(activityLogs, ({ one }) => ({
   }),
 }));
 
+export const articlesRelations = relations(articles, ({ one }) => ({
+  user: one(users, {
+    fields: [articles.userId],
+    references: [users.id],
+  }),
+  team: one(teams, {
+    fields: [articles.teamId],
+    references: [teams.id],
+  }),
+}));
+
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type Team = typeof teams.$inferSelect;
@@ -122,6 +154,8 @@ export type ActivityLog = typeof activityLogs.$inferSelect;
 export type NewActivityLog = typeof activityLogs.$inferInsert;
 export type Invitation = typeof invitations.$inferSelect;
 export type NewInvitation = typeof invitations.$inferInsert;
+export type Article = typeof articles.$inferSelect;
+export type NewArticle = typeof articles.$inferInsert;
 export type TeamDataWithMembers = Team & {
   teamMembers: (TeamMember & {
     user: Pick<User, 'id' | 'name' | 'email'>;


### PR DESCRIPTION
以下、日本語訳です:

---

このプルリクエストは、ダッシュボードにおける記事管理の新機能セットを導入するもので、記事の閲覧、編集、作成、削除が含まれます。また、コントリビューター向けの包括的なリポジトリガイドライン文書も追加されています。主な変更点は、堅牢なバリデーションとユーザー権限を備えた記事のCRUD操作の実装と、プロジェクト構造および開発プラクティスに関する明確なドキュメントの追加です。

**記事管理機能**

* `app/(dashboard)/articles/actions.ts` を追加し、記事の作成、更新、削除のためのサーバーアクションを実装。入力バリデーション、スラッグ生成、権限チェック、論理削除ロジックが含まれます。
* `app/(dashboard)/articles/[id]/page.tsx` を導入し、記事詳細ビューを実装。メタデータ、著者情報、ステータスバッジを表示し、確認とエラーハンドリングを備えた編集/削除アクションを提供します。([[app/(dashboard)/articles/[id]/page.tsxR1-R235](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-3d19ceeed7097c00bf0bb49629176f5becb219d2a1e19db157a55f8e7d116ce2R1-R235))
* `app/(dashboard)/articles/[id]/edit/page.tsx` を追加し、記事編集機能を実装。バリデーション、ステータス選択、成功/エラー時のユーザーフィードバックを備えたフォームを提供し、SWRを使用したデータ取得と楽観的UI更新を行います。([[app/(dashboard)/articles/[id]/edit/page.tsxR1-R286](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-a192044fc5a2dc63faef9dba96036d2c521ba5467252d274b5ffadb815befbe9R1-R286))

**ドキュメントとガイドライン**

* `AGENTS.md` を作成し、プロジェクト構造、コーディングスタイル、命名規則、テスト、コミット/PRプロセス、セキュリティのヒントをカバーする詳細なリポジトリガイドラインを提供。新しいコントリビューターのオンボーディングと一貫性の維持を支援します。