### PR TITLE
【第5回】記事管理 impl claude prompt roleplay+fewshot+cot+5w1h

### DIFF
--- a/app/(dashboard)/dashboard/articles/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/articles/[id]/edit/page.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useRouter } from 'next/navigation';
+import { useState, useEffect, use } from 'react';
+import { Loader2 } from 'lucide-react';
+import useSWR from 'swr';
+
+type Article = {
+  id: number;
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string | null;
+  status: string;
+};
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export default function EditArticlePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const { data: article, error: fetchError } = useSWR<Article>(
+    `/api/articles/${id}`,
+    fetcher
+  );
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError('');
+
+    const formData = new FormData(e.currentTarget);
+    const title = formData.get('title') as string;
+    const slug = formData.get('slug') as string;
+    const content = formData.get('content') as string;
+    const excerpt = formData.get('excerpt') as string;
+    const status = formData.get('status') as string;
+
+    try {
+      const response = await fetch(`/api/articles/${id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title,
+          slug,
+          content,
+          excerpt,
+          status,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || '記事の更新に失敗しました');
+      }
+
+      router.push('/dashboard/articles');
+      router.refresh();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (fetchError) {
+    return (
+      <section className="flex-1 p-4 lg:p-8">
+        <p className="text-red-500">記事の読み込みに失敗しました</p>
+      </section>
+    );
+  }
+
+  if (!article) {
+    return (
+      <section className="flex-1 p-4 lg:p-8">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="mb-6">
+        <h1 className="text-lg lg:text-2xl font-medium">記事編集</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>記事情報</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <Label htmlFor="title">タイトル</Label>
+              <Input
+                id="title"
+                name="title"
+                required
+                defaultValue={article.title}
+                placeholder="記事のタイトルを入力"
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="slug">スラッグ</Label>
+              <Input
+                id="slug"
+                name="slug"
+                required
+                defaultValue={article.slug}
+                placeholder="url-friendly-slug"
+              />
+              <p className="text-sm text-muted-foreground mt-1">
+                URLに使用されます（半角英数字とハイフンのみ）
+              </p>
+            </div>
+
+            <div>
+              <Label htmlFor="excerpt">要約</Label>
+              <Textarea
+                id="excerpt"
+                name="excerpt"
+                defaultValue={article.excerpt || ''}
+                placeholder="記事の要約を入力（任意）"
+                rows={3}
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="content">本文</Label>
+              <Textarea
+                id="content"
+                name="content"
+                required
+                defaultValue={article.content}
+                placeholder="記事の本文を入力"
+                rows={12}
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="status">ステータス</Label>
+              <Select name="status" defaultValue={article.status}>
+                <SelectTrigger>
+                  <SelectValue placeholder="ステータスを選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="draft">下書き</SelectItem>
+                  <SelectItem value="published">公開</SelectItem>
+                  <SelectItem value="unpublished">非公開</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {error && <p className="text-red-500 text-sm">{error}</p>}
+
+            <div className="flex gap-4">
+              <Button
+                type="submit"
+                disabled={isLoading}
+                className="bg-orange-500 hover:bg-orange-600 text-white"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    更新中...
+                  </>
+                ) : (
+                  '更新'
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => router.back()}
+                disabled={isLoading}
+              >
+                キャンセル
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/(dashboard)/dashboard/articles/new/page.tsx
+++ b/app/(dashboard)/dashboard/articles/new/page.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+
+export default function NewArticlePage() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError('');
+
+    const formData = new FormData(e.currentTarget);
+    const title = formData.get('title') as string;
+    const slug = formData.get('slug') as string;
+    const content = formData.get('content') as string;
+    const excerpt = formData.get('excerpt') as string;
+    const status = formData.get('status') as string;
+
+    try {
+      const response = await fetch('/api/articles', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title,
+          slug,
+          content,
+          excerpt,
+          status,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || '記事の作成に失敗しました');
+      }
+
+      router.push('/dashboard/articles');
+      router.refresh();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const generateSlug = (title: string) => {
+    return title
+      .toLowerCase()
+      .replace(/[^\w\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/--+/g, '-')
+      .trim();
+  };
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="mb-6">
+        <h1 className="text-lg lg:text-2xl font-medium">新規記事作成</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>記事情報</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <Label htmlFor="title">タイトル</Label>
+              <Input
+                id="title"
+                name="title"
+                required
+                placeholder="記事のタイトルを入力"
+                onChange={(e) => {
+                  const slugInput = document.getElementById(
+                    'slug'
+                  ) as HTMLInputElement;
+                  if (slugInput && !slugInput.value) {
+                    slugInput.value = generateSlug(e.target.value);
+                  }
+                }}
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="slug">スラッグ</Label>
+              <Input
+                id="slug"
+                name="slug"
+                required
+                placeholder="url-friendly-slug"
+              />
+              <p className="text-sm text-muted-foreground mt-1">
+                URLに使用されます（半角英数字とハイフンのみ）
+              </p>
+            </div>
+
+            <div>
+              <Label htmlFor="excerpt">要約</Label>
+              <Textarea
+                id="excerpt"
+                name="excerpt"
+                placeholder="記事の要約を入力（任意）"
+                rows={3}
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="content">本文</Label>
+              <Textarea
+                id="content"
+                name="content"
+                required
+                placeholder="記事の本文を入力"
+                rows={12}
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="status">ステータス</Label>
+              <Select name="status" defaultValue="draft">
+                <SelectTrigger>
+                  <SelectValue placeholder="ステータスを選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="draft">下書き</SelectItem>
+                  <SelectItem value="published">公開</SelectItem>
+                  <SelectItem value="unpublished">非公開</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {error && <p className="text-red-500 text-sm">{error}</p>}
+
+            <div className="flex gap-4">
+              <Button
+                type="submit"
+                disabled={isLoading}
+                className="bg-orange-500 hover:bg-orange-600 text-white"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    作成中...
+                  </>
+                ) : (
+                  '作成'
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => router.back()}
+                disabled={isLoading}
+              >
+                キャンセル
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/(dashboard)/dashboard/articles/page.tsx
+++ b/app/(dashboard)/dashboard/articles/page.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import useSWR from 'swr';
+import { useRouter } from 'next/navigation';
+import { PlusCircle, Pencil, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+type Article = {
+  id: number;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  status: string;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  author: {
+    id: number;
+    name: string | null;
+    email: string;
+  } | null;
+};
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export default function ArticlesPage() {
+  const router = useRouter();
+  const { data: articles, mutate } = useSWR<Article[]>('/api/articles', fetcher);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('この記事を削除してもよろしいですか？')) {
+      return;
+    }
+
+    setDeletingId(id);
+    try {
+      const response = await fetch(`/api/articles/${id}`, {
+        method: 'DELETE',
+      });
+
+      if (response.ok) {
+        mutate();
+      } else {
+        alert('削除に失敗しました');
+      }
+    } catch (error) {
+      alert('削除に失敗しました');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case 'published':
+        return <Badge className="bg-green-500">公開</Badge>;
+      case 'draft':
+        return <Badge variant="secondary">下書き</Badge>;
+      case 'unpublished':
+        return <Badge variant="outline">非公開</Badge>;
+      default:
+        return <Badge>{status}</Badge>;
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  };
+
+  return (
+    <section className="flex-1 p-4 lg:p-8">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-lg lg:text-2xl font-medium">記事管理</h1>
+        <Button
+          onClick={() => router.push('/dashboard/articles/new')}
+          className="bg-orange-500 hover:bg-orange-600 text-white"
+        >
+          <PlusCircle className="mr-2 h-4 w-4" />
+          新規作成
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>記事一覧</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!articles ? (
+            <div className="text-center py-8 text-muted-foreground">
+              読み込み中...
+            </div>
+          ) : articles.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              記事がありません
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>タイトル</TableHead>
+                  <TableHead>ステータス</TableHead>
+                  <TableHead>作成日</TableHead>
+                  <TableHead className="text-right">操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {articles.map((article) => (
+                  <TableRow key={article.id}>
+                    <TableCell className="font-medium">
+                      {article.title}
+                    </TableCell>
+                    <TableCell>{getStatusBadge(article.status)}</TableCell>
+                    <TableCell>{formatDate(article.createdAt)}</TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            router.push(`/dashboard/articles/${article.id}/edit`)
+                          }
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleDelete(article.id)}
+                          disabled={deletingId === article.id}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/api/articles/[id]/route.ts
+++ b/app/api/articles/[id]/route.ts
@@ -1,0 +1,177 @@
+import { db } from '@/lib/db/drizzle';
+import { articles, articleCategories, articleTags, categories, tags, users } from '@/lib/db/schema';
+import { getUser } from '@/lib/db/queries';
+import { eq, and } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const articleId = parseInt(id);
+
+  if (isNaN(articleId)) {
+    return Response.json({ error: 'Invalid article ID' }, { status: 400 });
+  }
+
+  const user = await getUser();
+
+  const result = await db.query.articles.findFirst({
+    where: eq(articles.id, articleId),
+    with: {
+      author: {
+        columns: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+      articleCategories: {
+        with: {
+          category: true,
+        },
+      },
+      articleTags: {
+        with: {
+          tag: true,
+        },
+      },
+    },
+  });
+
+  if (!result) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  // 非公開記事は作成者のみ閲覧可能
+  if (result.status !== 'published' && (!user || result.userId !== user.id)) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  return Response.json(result);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const articleId = parseInt(id);
+
+  if (isNaN(articleId)) {
+    return Response.json({ error: 'Invalid article ID' }, { status: 400 });
+  }
+
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // 記事の所有者確認
+  const existingArticle = await db.query.articles.findFirst({
+    where: eq(articles.id, articleId),
+  });
+
+  if (!existingArticle) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  if (existingArticle.userId !== user.id) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { title, slug, content, excerpt, status, categoryIds, tagIds } = body;
+
+  try {
+    const [updatedArticle] = await db
+      .update(articles)
+      .set({
+        title,
+        slug,
+        content,
+        excerpt,
+        status,
+        publishedAt:
+          status === 'published' && !existingArticle.publishedAt
+            ? new Date()
+            : existingArticle.publishedAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(articles.id, articleId))
+      .returning();
+
+    // カテゴリーを更新
+    if (categoryIds !== undefined) {
+      await db.delete(articleCategories).where(eq(articleCategories.articleId, articleId));
+      if (categoryIds.length > 0) {
+        await db.insert(articleCategories).values(
+          categoryIds.map((categoryId: number) => ({
+            articleId,
+            categoryId,
+          }))
+        );
+      }
+    }
+
+    // タグを更新
+    if (tagIds !== undefined) {
+      await db.delete(articleTags).where(eq(articleTags.articleId, articleId));
+      if (tagIds.length > 0) {
+        await db.insert(articleTags).values(
+          tagIds.map((tagId: number) => ({
+            articleId,
+            tagId,
+          }))
+        );
+      }
+    }
+
+    return Response.json(updatedArticle);
+  } catch (error: any) {
+    if (error.code === '23505') {
+      return Response.json({ error: 'Slug already exists' }, { status: 409 });
+    }
+    return Response.json({ error: 'Failed to update article' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const articleId = parseInt(id);
+
+  if (isNaN(articleId)) {
+    return Response.json({ error: 'Invalid article ID' }, { status: 400 });
+  }
+
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // 記事の所有者確認
+  const existingArticle = await db.query.articles.findFirst({
+    where: eq(articles.id, articleId),
+  });
+
+  if (!existingArticle) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  if (existingArticle.userId !== user.id) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // カテゴリーとタグの紐付けを削除
+  await db.delete(articleCategories).where(eq(articleCategories.articleId, articleId));
+  await db.delete(articleTags).where(eq(articleTags.articleId, articleId));
+
+  // 記事を削除
+  await db.delete(articles).where(eq(articles.id, articleId));
+
+  return Response.json({ success: true });
+}

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,0 +1,112 @@
+import { db } from '@/lib/db/drizzle';
+import { articles, articleCategories, articleTags, categories, tags, users } from '@/lib/db/schema';
+import { getUser } from '@/lib/db/queries';
+import { eq, desc, and } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const status = searchParams.get('status');
+  const userId = searchParams.get('userId');
+
+  const user = await getUser();
+
+  let query = db
+    .select({
+      id: articles.id,
+      title: articles.title,
+      slug: articles.slug,
+      excerpt: articles.excerpt,
+      status: articles.status,
+      publishedAt: articles.publishedAt,
+      createdAt: articles.createdAt,
+      updatedAt: articles.updatedAt,
+      author: {
+        id: users.id,
+        name: users.name,
+        email: users.email,
+      },
+    })
+    .from(articles)
+    .leftJoin(users, eq(articles.userId, users.id))
+    .orderBy(desc(articles.createdAt));
+
+  const conditions = [];
+
+  // 認証済みユーザーの場合、自分の記事または公開記事を取得
+  if (user) {
+    if (status) {
+      conditions.push(eq(articles.status, status));
+    }
+    if (userId) {
+      conditions.push(eq(articles.userId, parseInt(userId)));
+    }
+  } else {
+    // 未認証の場合は公開記事のみ
+    conditions.push(eq(articles.status, 'published'));
+  }
+
+  if (conditions.length > 0) {
+    query = query.where(and(...conditions)) as typeof query;
+  }
+
+  const result = await query;
+
+  return Response.json(result);
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { title, slug, content, excerpt, status, categoryIds, tagIds } = body;
+
+  if (!title || !slug || !content) {
+    return Response.json({ error: 'Missing required fields' }, { status: 400 });
+  }
+
+  try {
+    const [article] = await db
+      .insert(articles)
+      .values({
+        userId: user.id,
+        title,
+        slug,
+        content,
+        excerpt,
+        status: status || 'draft',
+        publishedAt: status === 'published' ? new Date() : null,
+      })
+      .returning();
+
+    // カテゴリーの紐付け
+    if (categoryIds && categoryIds.length > 0) {
+      await db.insert(articleCategories).values(
+        categoryIds.map((categoryId: number) => ({
+          articleId: article.id,
+          categoryId,
+        }))
+      );
+    }
+
+    // タグの紐付け
+    if (tagIds && tagIds.length > 0) {
+      await db.insert(articleTags).values(
+        tagIds.map((tagId: number) => ({
+          articleId: article.id,
+          tagId,
+        }))
+      );
+    }
+
+    return Response.json(article, { status: 201 });
+  } catch (error: any) {
+    if (error.code === '23505') {
+      return Response.json({ error: 'Slug already exists' }, { status: 409 });
+    }
+    return Response.json({ error: 'Failed to create article' }, { status: 500 });
+  }
+}

--- a/app/api/articles/slug/[slug]/route.ts
+++ b/app/api/articles/slug/[slug]/route.ts
@@ -1,0 +1,45 @@
+import { db } from '@/lib/db/drizzle';
+import { articles, users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+
+  const result = await db.query.articles.findFirst({
+    where: eq(articles.slug, slug),
+    with: {
+      author: {
+        columns: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+      articleCategories: {
+        with: {
+          category: true,
+        },
+      },
+      articleTags: {
+        with: {
+          tag: true,
+        },
+      },
+    },
+  });
+
+  if (!result) {
+    return Response.json({ error: 'Article not found' }, { status: 404 });
+  }
+
+  // 公開記事のみアクセス可能
+  if (result.status !== 'published') {
+    return Response.json({ error: 'Article not published' }, { status: 404 });
+  }
+
+  return Response.json(result);
+}

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,42 @@
+import { db } from '@/lib/db/drizzle';
+import { categories } from '@/lib/db/schema';
+import { getUser } from '@/lib/db/queries';
+import { desc } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+
+export async function GET() {
+  const result = await db
+    .select()
+    .from(categories)
+    .orderBy(desc(categories.createdAt));
+
+  return Response.json(result);
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { name, slug } = body;
+
+  if (!name || !slug) {
+    return Response.json({ error: 'Missing required fields' }, { status: 400 });
+  }
+
+  try {
+    const [category] = await db
+      .insert(categories)
+      .values({ name, slug })
+      .returning();
+
+    return Response.json(category, { status: 201 });
+  } catch (error: any) {
+    if (error.code === '23505') {
+      return Response.json({ error: 'Slug already exists' }, { status: 409 });
+    }
+    return Response.json({ error: 'Failed to create category' }, { status: 500 });
+  }
+}

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,0 +1,42 @@
+import { db } from '@/lib/db/drizzle';
+import { tags } from '@/lib/db/schema';
+import { getUser } from '@/lib/db/queries';
+import { desc } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+
+export async function GET() {
+  const result = await db
+    .select()
+    .from(tags)
+    .orderBy(desc(tags.createdAt));
+
+  return Response.json(result);
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getUser();
+  if (!user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { name, slug } = body;
+
+  if (!name || !slug) {
+    return Response.json({ error: 'Missing required fields' }, { status: 400 });
+  }
+
+  try {
+    const [tag] = await db
+      .insert(tags)
+      .values({ name, slug })
+      .returning();
+
+    return Response.json(tag, { status: 201 });
+  } catch (error: any) {
+    if (error.code === '23505') {
+      return Response.json({ error: 'Slug already exists' }, { status: 409 });
+    }
+    return Response.json({ error: 'Failed to create tag' }, { status: 500 });
+  }
+}

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -1,0 +1,142 @@
+import { db } from '@/lib/db/drizzle';
+import { articles } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { notFound } from 'next/navigation';
+
+type Article = {
+  id: number;
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string | null;
+  status: string;
+  publishedAt: string | null;
+  createdAt: string;
+  author: {
+    id: number;
+    name: string | null;
+    email: string;
+  };
+  articleCategories: Array<{
+    category: {
+      id: number;
+      name: string;
+      slug: string;
+    };
+  }>;
+  articleTags: Array<{
+    tag: {
+      id: number;
+      name: string;
+      slug: string;
+    };
+  }>;
+};
+
+async function getArticle(slug: string): Promise<Article | null> {
+  const result = await db.query.articles.findFirst({
+    where: eq(articles.slug, slug),
+    with: {
+      author: {
+        columns: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+      articleCategories: {
+        with: {
+          category: true,
+        },
+      },
+      articleTags: {
+        with: {
+          tag: true,
+        },
+      },
+    },
+  });
+
+  if (!result || result.status !== 'published') {
+    return null;
+  }
+
+  return result as Article;
+}
+
+export default async function ArticlePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const article = await getArticle(slug);
+
+  if (!article) {
+    notFound();
+  }
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="container mx-auto px-4 py-8 max-w-4xl">
+        <article>
+          <header className="mb-8">
+            <h1 className="text-4xl font-bold mb-4">{article.title}</h1>
+
+            <div className="flex items-center gap-4 text-sm text-muted-foreground mb-4">
+              <span>
+                投稿者: {article.author.name || article.author.email}
+              </span>
+              <span>•</span>
+              <time dateTime={article.publishedAt || article.createdAt}>
+                {formatDate(article.publishedAt || article.createdAt)}
+              </time>
+            </div>
+
+            {article.excerpt && (
+              <p className="text-lg text-muted-foreground mb-4">
+                {article.excerpt}
+              </p>
+            )}
+
+            {(article.articleCategories.length > 0 ||
+              article.articleTags.length > 0) && (
+              <div className="flex flex-wrap gap-2">
+                {article.articleCategories.map((ac) => (
+                  <span
+                    key={ac.category.id}
+                    className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary"
+                  >
+                    {ac.category.name}
+                  </span>
+                ))}
+                {article.articleTags.map((at) => (
+                  <span
+                    key={at.tag.id}
+                    className="inline-flex items-center rounded-full bg-secondary px-3 py-1 text-sm font-medium"
+                  >
+                    #{at.tag.name}
+                  </span>
+                ))}
+              </div>
+            )}
+          </header>
+
+          <div className="prose prose-lg dark:prose-invert max-w-none">
+            {article.content.split('\n').map((paragraph, index) => (
+              <p key={index}>{paragraph}</p>
+            ))}
+          </div>
+        </article>
+      </main>
+    </div>
+  );
+}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 md:text-sm',
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1',
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1',
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = 'popper', ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/lib/db/migrations/0001_lethal_big_bertha.sql
+++ b/lib/db/migrations/0001_lethal_big_bertha.sql
@@ -1,0 +1,47 @@
+CREATE TABLE "article_categories" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"article_id" integer NOT NULL,
+	"category_id" integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "article_tags" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"article_id" integer NOT NULL,
+	"tag_id" integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "articles" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"slug" varchar(255) NOT NULL,
+	"content" text NOT NULL,
+	"excerpt" text,
+	"status" varchar(20) DEFAULT 'draft' NOT NULL,
+	"published_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "articles_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "categories" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"slug" varchar(100) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "categories_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "tags" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(50) NOT NULL,
+	"slug" varchar(50) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "tags_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "article_categories" ADD CONSTRAINT "article_categories_article_id_articles_id_fk" FOREIGN KEY ("article_id") REFERENCES "public"."articles"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "article_categories" ADD CONSTRAINT "article_categories_category_id_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."categories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "article_tags" ADD CONSTRAINT "article_tags_article_id_articles_id_fk" FOREIGN KEY ("article_id") REFERENCES "public"."articles"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "article_tags" ADD CONSTRAINT "article_tags_tag_id_tags_id_fk" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "articles" ADD CONSTRAINT "articles_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/lib/db/migrations/meta/0001_snapshot.json
+++ b/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,713 @@
+{
+  "id": "c8226f24-3b81-479e-a809-a498d236be56",
+  "prevId": "261fd993-fb2c-43e7-89d6-cd58786c5f58",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_logs_team_id_teams_id_fk": {
+          "name": "activity_logs_team_id_teams_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_logs_user_id_users_id_fk": {
+          "name": "activity_logs_user_id_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_categories": {
+      "name": "article_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_categories_article_id_articles_id_fk": {
+          "name": "article_categories_article_id_articles_id_fk",
+          "tableFrom": "article_categories",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "article_categories_category_id_categories_id_fk": {
+          "name": "article_categories_category_id_categories_id_fk",
+          "tableFrom": "article_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_tags": {
+      "name": "article_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_tags_article_id_articles_id_fk": {
+          "name": "article_tags_article_id_articles_id_fk",
+          "tableFrom": "article_tags",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "article_tags_tag_id_tags_id_fk": {
+          "name": "article_tags_tag_id_tags_id_fk",
+          "tableFrom": "article_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "articles_user_id_users_id_fk": {
+          "name": "articles_user_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "articles_slug_unique": {
+          "name": "articles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_team_id_teams_id_fk": {
+          "name": "invitations_team_id_teams_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_stripe_customer_id_unique": {
+          "name": "teams_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "teams_stripe_subscription_id_unique": {
+          "name": "teams_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1726443359662,
       "tag": "0000_soft_the_anarchist",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1759579081614,
+      "tag": "0001_lethal_big_bertha",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -128,6 +128,101 @@ export type TeamDataWithMembers = Team & {
   })[];
 };
 
+export const articles = pgTable('articles', {
+  id: serial('id').primaryKey(),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id),
+  title: varchar('title', { length: 255 }).notNull(),
+  slug: varchar('slug', { length: 255 }).notNull().unique(),
+  content: text('content').notNull(),
+  excerpt: text('excerpt'),
+  status: varchar('status', { length: 20 }).notNull().default('draft'),
+  publishedAt: timestamp('published_at'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});
+
+export const categories = pgTable('categories', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 100 }).notNull(),
+  slug: varchar('slug', { length: 100 }).notNull().unique(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});
+
+export const tags = pgTable('tags', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 50 }).notNull(),
+  slug: varchar('slug', { length: 50 }).notNull().unique(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});
+
+export const articleCategories = pgTable('article_categories', {
+  id: serial('id').primaryKey(),
+  articleId: integer('article_id')
+    .notNull()
+    .references(() => articles.id),
+  categoryId: integer('category_id')
+    .notNull()
+    .references(() => categories.id),
+});
+
+export const articleTags = pgTable('article_tags', {
+  id: serial('id').primaryKey(),
+  articleId: integer('article_id')
+    .notNull()
+    .references(() => articles.id),
+  tagId: integer('tag_id')
+    .notNull()
+    .references(() => tags.id),
+});
+
+export const articlesRelations = relations(articles, ({ one, many }) => ({
+  author: one(users, {
+    fields: [articles.userId],
+    references: [users.id],
+  }),
+  articleCategories: many(articleCategories),
+  articleTags: many(articleTags),
+}));
+
+export const categoriesRelations = relations(categories, ({ many }) => ({
+  articleCategories: many(articleCategories),
+}));
+
+export const tagsRelations = relations(tags, ({ many }) => ({
+  articleTags: many(articleTags),
+}));
+
+export const articleCategoriesRelations = relations(articleCategories, ({ one }) => ({
+  article: one(articles, {
+    fields: [articleCategories.articleId],
+    references: [articles.id],
+  }),
+  category: one(categories, {
+    fields: [articleCategories.categoryId],
+    references: [categories.id],
+  }),
+}));
+
+export const articleTagsRelations = relations(articleTags, ({ one }) => ({
+  article: one(articles, {
+    fields: [articleTags.articleId],
+    references: [articles.id],
+  }),
+  tag: one(tags, {
+    fields: [articleTags.tagId],
+    references: [tags.id],
+  }),
+}));
+
+export type Article = typeof articles.$inferSelect;
+export type NewArticle = typeof articles.$inferInsert;
+export type Category = typeof categories.$inferSelect;
+export type NewCategory = typeof categories.$inferInsert;
+export type Tag = typeof tags.$inferSelect;
+export type NewTag = typeof tags.$inferInsert;
+
 export enum ActivityType {
   SIGN_UP = 'SIGN_UP',
   SIGN_IN = 'SIGN_IN',


### PR DESCRIPTION
# prompt

```
あなたはNext.js 14とTypeScriptの専門家です。
フルスタック開発の経験が豊富です。

以下は、このプロジェクトの既存コンポーネントの例です：

【例1: app/dashboard/page.tsx】
@app/(dashboard)/dashboard/general/page.tsx 

【例2: components/ui/button.tsx】
@components/ui/button.tsx 

記事管理機能を追加してください。

実装する前に、以下を段階的に考えてください：
1. 必要なデータベーステーブル設計
2. 必要なAPIエンドポイント
3. フロントエンドのコンポーネント構成
4. 認証・認可の実装方法
5. エラーハンドリングの方針

各ステップを明確に説明してから、実装を始めてください。

以下の要件で記事管理機能を追加してください：

【What - 何を】
- 記事のCRUD機能（作成・読取・更新・削除）
- 記事ステータス管理（下書き・公開・非公開）
- タグ・カテゴリ機能

【Who - 誰が】
- 認証済みユーザーのみが作成・編集可能
- 公開記事は全ユーザーが閲覧可能

【When - いつ】
- 今回のスプリントで基本機能を実装
- 公開スケジュール機能は次フェーズ

【Where - どこで】
- /dashboard/articles 配下に配置
- 既存のダッシュボードレイアウトを使用

【Why - なぜ】
- ユーザーがブログ記事を管理できるようにするため
- SEO最適化された記事ページを提供するため

【How - どのように】
- Next.js 14 App Router使用
- Server Componentsを優先的に使用
- shadcn/uiコンポーネント使用
```

# comment

このプルリクエストは、ダッシュボードにおける記事の完全なCRUD(作成、読み取り、更新、削除)機能を追加するもので、記事の一覧表示、作成、編集、削除のためのAPIエンドポイントとクライアントサイドページが含まれています。実装には、ユーザー認証チェック、所有権の検証、記事のカテゴリーとタグのサポートが含まれています。

**記事管理のためのAPIエンドポイント:**

* `app/api/articles/route.ts`に記事の一覧取得と作成のためのRESTful APIエンドポイントを追加し、認証、ステータス/ユーザーによるフィルタリング、カテゴリー/タグのリンク機能をサポート。
* `app/api/articles/[id]/route.ts`に個別記事の取得、更新、削除のためのエンドポイントを実装し、厳格な所有権チェックと関連カテゴリー・タグの更新/削除機能を含む。([[app/api/articles/[id]/route.tsR1-R177](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-a8269d7e5fcd9cdd451912c93b3a8458728faf0bd5170b529ff95ad902795132R1-R177))
* `app/api/articles/slug/[slug]/route.ts`に、スラッグで公開済み記事を取得するエンドポイントを追加し、未公開記事へのアクセスを制限。([[app/api/articles/slug/[slug]/route.tsR1-R45](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-680e641d20581ba675955831a5ccefde323e10973acbe46fbb3a399f18400cacR1-R45))

**記事CRUD用のダッシュボードUI:**

* `app/(dashboard)/dashboard/articles/page.tsx`を作成し、ステータスバッジ、作成日、編集・削除アクションを含む記事一覧を表示。確認ダイアログとローディング状態を含む。
* `app/(dashboard)/dashboard/articles/new/page.tsx`を追加し、新規記事作成用のフォームを実装。バリデーション、ステータス選択、タイトルからの自動スラッグ生成機能を含む。
* `app/(dashboard)/dashboard/articles/[id]/edit/page.tsx`を追加し、既存記事の編集機能を実装。フォームの事前入力、エラーハンドリング、ステータス管理を含む。([[app/(dashboard)/dashboard/articles/[id]/edit/page.tsxR1-R208](https://claude.ai/chat/ab447953-139c-443f-8cd2-b6a375bc4c78)](diffhunk://#diff-55ec0b7133516b148543dbd5d24b408edef3cf5644418745d38c492db42e097eR1-R208))