### PR TITLE
【第6回】記事管理 リファクタ claude init + architecture + authorization + ui

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,14 +333,17 @@ All articles have these required fields for authorization ([lib/db/schema.ts:132
 
 **Follow the established color scheme:**
 - The project uses a complete design token system defined in [app/globals.css](app/globals.css)
+- **Primary brand color is orange** (`orange-500`/`orange-600` in Tailwind, or `primary` token in the design system)
 - **ALWAYS use semantic color tokens** instead of arbitrary colors:
   - `text-foreground`, `text-muted-foreground` for text
   - `bg-background`, `bg-card`, `bg-muted`, `bg-accent` for backgrounds
   - `border-border`, `border-input` for borders
   - `text-destructive`, `bg-destructive` for destructive actions
-  - `text-primary`, `bg-primary` for primary actions
+  - `text-primary`, `bg-primary` for primary actions (CTAs, submit buttons, brand highlights)
+  - `text-primary-foreground`, `bg-primary-foreground` for text/background on primary-colored elements
+- The `primary` token is set to orange (HSL: `24.6 95% 53.1%` for light mode, `20.5 90.2% 48.2%` for dark mode)
 - Support both light and dark modes via CSS variables
-- Reference color tokens in `globals.css:86-196` for the complete palette
+- Reference color tokens in `globals.css:85-227` for the complete palette
 
 **Tailwind utility usage:**
 - Use Tailwind utility classes exclusively (no CSS modules or inline styles)
@@ -425,19 +428,22 @@ interface Props extends VariantProps<typeof componentVariants> {
 
 All color tokens support light/dark modes automatically. Key tokens:
 
-| Token | Usage |
-|-------|-------|
-| `foreground` | Primary text color |
-| `muted-foreground` | Secondary/helper text |
-| `background` | Page background |
-| `card` / `card-foreground` | Card containers |
-| `border` / `input` | Border colors (same value) |
-| `primary` / `primary-foreground` | Primary actions/CTAs |
-| `destructive` / `destructive-foreground` | Delete/error actions |
-| `accent` / `accent-foreground` | Hover/focus states |
-| `ring` | Focus ring color |
+| Token | Usage | Example |
+|-------|-------|---------|
+| `foreground` | Primary text color | Main headings, body text |
+| `muted-foreground` | Secondary/helper text | Descriptions, labels |
+| `background` | Page background | Main page container |
+| `card` / `card-foreground` | Card containers | Content cards, panels |
+| `border` / `input` | Border colors (same value) | Form inputs, dividers |
+| `primary` / `primary-foreground` | **Primary actions/CTAs (Orange)** | Submit buttons, "New" buttons, active filters |
+| `destructive` / `destructive-foreground` | Delete/error actions | Delete buttons, error messages |
+| `accent` / `accent-foreground` | Hover/focus states, success messages | Hover backgrounds, success alerts |
+| `secondary` / `secondary-foreground` | Secondary actions | Badge backgrounds, secondary buttons |
+| `ring` | Focus ring color (Orange) | Focus outlines on interactive elements |
 
 Use these tokens via Tailwind classes: `bg-{token}`, `text-{token}`, `border-{token}`.
+
+**Migration note:** If you find hardcoded `orange-500` or `orange-600` classes in existing code, prefer using `bg-primary` and `hover:bg-primary/90` instead for consistency with the design system.
 
 ## Testing
 

--- a/app/(dashboard)/dashboard/activity/page.tsx
+++ b/app/(dashboard)/dashboard/activity/page.tsx
@@ -91,8 +91,8 @@ export default async function ActivityPage() {
 
                 return (
                   <li key={log.id} className="flex items-center space-x-4">
-                    <div className="bg-orange-100 rounded-full p-2">
-                      <Icon className="w-5 h-5 text-orange-600" />
+                    <div className="bg-primary/10 rounded-full p-2">
+                      <Icon className="w-5 h-5 text-primary" />
                     </div>
                     <div className="flex-1">
                       <p className="text-sm font-medium text-foreground">
@@ -109,7 +109,7 @@ export default async function ActivityPage() {
             </ul>
           ) : (
             <div className="flex flex-col items-center justify-center text-center py-12">
-              <AlertCircle className="h-12 w-12 text-orange-500 mb-4" />
+              <AlertCircle className="h-12 w-12 text-primary mb-4" />
               <h3 className="text-lg font-semibold text-foreground mb-2">
                 No activity yet
               </h3>

--- a/app/(dashboard)/dashboard/articles/article-form.tsx
+++ b/app/(dashboard)/dashboard/articles/article-form.tsx
@@ -235,7 +235,7 @@ export function ArticleForm({ article, categories }: ArticleFormProps) {
           )}
           {formState.success && (
             <div
-              className="p-3 rounded-md bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-100 text-sm"
+              className="p-3 rounded-md bg-accent text-accent-foreground text-sm"
               role="status"
             >
               {formState.success}
@@ -247,7 +247,6 @@ export function ArticleForm({ article, categories }: ArticleFormProps) {
             <Button
               type="submit"
               disabled={isPending}
-              className="bg-orange-500 hover:bg-orange-600"
               aria-label={isEditMode ? '記事を更新' : '記事を作成'}
             >
               {isPending ? (

--- a/app/(dashboard)/dashboard/general/page.tsx
+++ b/app/(dashboard)/dashboard/general/page.tsx
@@ -94,14 +94,13 @@ export default function GeneralPage() {
               <AccountFormWithData state={state} />
             </Suspense>
             {state.error && (
-              <p className="text-red-500 text-sm">{state.error}</p>
+              <p className="text-destructive text-sm">{state.error}</p>
             )}
             {state.success && (
-              <p className="text-green-500 text-sm">{state.success}</p>
+              <p className="text-accent-foreground text-sm">{state.success}</p>
             )}
             <Button
               type="submit"
-              className="bg-orange-500 hover:bg-orange-600 text-white"
               disabled={isPending}
             >
               {isPending ? (

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -170,7 +170,7 @@ function TeamMembers() {
           ))}
         </ul>
         {removeState?.error && (
-          <p className="text-red-500 mt-4">{removeState.error}</p>
+          <p className="text-destructive mt-4">{removeState.error}</p>
         )}
       </CardContent>
     </Card>
@@ -234,14 +234,13 @@ function InviteTeamMember() {
             </RadioGroup>
           </div>
           {inviteState?.error && (
-            <p className="text-red-500">{inviteState.error}</p>
+            <p className="text-destructive">{inviteState.error}</p>
           )}
           {inviteState?.success && (
-            <p className="text-green-500">{inviteState.success}</p>
+            <p className="text-accent-foreground">{inviteState.success}</p>
           )}
           <Button
             type="submit"
-            className="bg-orange-500 hover:bg-orange-600 text-white"
             disabled={isInvitePending || !isOwner}
           >
             {isInvitePending ? (

--- a/app/(dashboard)/dashboard/security/page.tsx
+++ b/app/(dashboard)/dashboard/security/page.tsx
@@ -89,14 +89,13 @@ export default function SecurityPage() {
               />
             </div>
             {passwordState.error && (
-              <p className="text-red-500 text-sm">{passwordState.error}</p>
+              <p className="text-destructive text-sm">{passwordState.error}</p>
             )}
             {passwordState.success && (
-              <p className="text-green-500 text-sm">{passwordState.success}</p>
+              <p className="text-accent-foreground text-sm">{passwordState.success}</p>
             )}
             <Button
               type="submit"
-              className="bg-orange-500 hover:bg-orange-600 text-white"
               disabled={isPasswordPending}
             >
               {isPasswordPending ? (
@@ -139,12 +138,11 @@ export default function SecurityPage() {
               />
             </div>
             {deleteState.error && (
-              <p className="text-red-500 text-sm">{deleteState.error}</p>
+              <p className="text-destructive text-sm">{deleteState.error}</p>
             )}
             <Button
               type="submit"
               variant="destructive"
-              className="bg-red-600 hover:bg-red-700"
               disabled={isDeletePending}
             >
               {isDeletePending ? (

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -84,7 +84,7 @@ function Header() {
     <header className="border-b border-border">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
         <Link href="/" className="flex items-center">
-          <CircleIcon className="h-6 w-6 text-orange-500" />
+          <CircleIcon className="h-6 w-6 text-primary" />
           <span className="ml-2 text-xl font-semibold text-foreground">ACME</span>
         </Link>
         <div className="flex items-center space-x-4">

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -11,7 +11,7 @@ export default function HomePage() {
             <div className="sm:text-center md:max-w-2xl md:mx-auto lg:col-span-6 lg:text-left">
               <h1 className="text-4xl font-bold text-foreground tracking-tight sm:text-5xl md:text-6xl">
                 Build Your SaaS
-                <span className="block text-orange-500">Faster Than Ever</span>
+                <span className="block text-primary">Faster Than Ever</span>
               </h1>
               <p className="mt-3 text-base text-muted-foreground sm:mt-5 sm:text-xl lg:text-lg xl:text-xl">
                 Launch your SaaS product in record time with our powerful,
@@ -45,7 +45,7 @@ export default function HomePage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="lg:grid lg:grid-cols-3 lg:gap-8">
             <div>
-              <div className="flex items-center justify-center h-12 w-12 rounded-md bg-orange-500 text-white">
+              <div className="flex items-center justify-center h-12 w-12 rounded-md bg-primary text-primary-foreground">
                 <svg viewBox="0 0 24 24" className="h-6 w-6">
                   <path
                     fill="currentColor"
@@ -65,7 +65,7 @@ export default function HomePage() {
             </div>
 
             <div className="mt-10 lg:mt-0">
-              <div className="flex items-center justify-center h-12 w-12 rounded-md bg-orange-500 text-white">
+              <div className="flex items-center justify-center h-12 w-12 rounded-md bg-primary text-primary-foreground">
                 <Database className="h-6 w-6" />
               </div>
               <div className="mt-5">
@@ -80,7 +80,7 @@ export default function HomePage() {
             </div>
 
             <div className="mt-10 lg:mt-0">
-              <div className="flex items-center justify-center h-12 w-12 rounded-md bg-orange-500 text-white">
+              <div className="flex items-center justify-center h-12 w-12 rounded-md bg-primary text-primary-foreground">
                 <CreditCard className="h-6 w-6" />
               </div>
               <div className="mt-5">

--- a/app/(dashboard)/pricing/page.tsx
+++ b/app/(dashboard)/pricing/page.tsx
@@ -80,7 +80,7 @@ function PricingCard({
       <ul className="space-y-4 mb-8">
         {features.map((feature, index) => (
           <li key={index} className="flex items-start">
-            <Check className="h-5 w-5 text-orange-500 mr-2 mt-0.5 flex-shrink-0" />
+            <Check className="h-5 w-5 text-primary mr-2 mt-0.5 flex-shrink-0" />
             <span className="text-foreground">{feature}</span>
           </li>
         ))}

--- a/app/(login)/login.tsx
+++ b/app/(login)/login.tsx
@@ -24,7 +24,7 @@ export function Login({ mode = 'signin' }: { mode?: 'signin' | 'signup' }) {
     <div className="min-h-[100dvh] flex flex-col justify-center py-12 px-4 sm:px-6 lg:px-8 bg-gray-50">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="flex justify-center">
-          <CircleIcon className="h-12 w-12 text-orange-500" />
+          <CircleIcon className="h-12 w-12 text-primary" />
         </div>
         <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
           {mode === 'signin'
@@ -54,7 +54,7 @@ export function Login({ mode = 'signin' }: { mode?: 'signin' | 'signup' }) {
                 defaultValue={state.email}
                 required
                 maxLength={50}
-                className="appearance-none rounded-full relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-orange-500 focus:border-orange-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-full relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary focus:border-primary focus:z-10 sm:text-sm"
                 placeholder="Enter your email"
               />
             </div>
@@ -79,20 +79,20 @@ export function Login({ mode = 'signin' }: { mode?: 'signin' | 'signup' }) {
                 required
                 minLength={8}
                 maxLength={100}
-                className="appearance-none rounded-full relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-orange-500 focus:border-orange-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-full relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary focus:border-primary focus:z-10 sm:text-sm"
                 placeholder="Enter your password"
               />
             </div>
           </div>
 
           {state?.error && (
-            <div className="text-red-500 text-sm">{state.error}</div>
+            <div className="text-destructive text-sm">{state.error}</div>
           )}
 
           <div>
             <Button
               type="submit"
-              className="w-full flex justify-center items-center py-2 px-4 border border-transparent rounded-full shadow-sm text-sm font-medium text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500"
+              className="w-full flex justify-center items-center py-2 px-4 border border-transparent rounded-full shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
               disabled={pending}
             >
               {pending ? (
@@ -128,7 +128,7 @@ export function Login({ mode = 'signin' }: { mode?: 'signin' | 'signup' }) {
               href={`${mode === 'signin' ? '/sign-up' : '/sign-in'}${
                 redirect ? `?redirect=${redirect}` : ''
               }${priceId ? `&priceId=${priceId}` : ''}`}
-              className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-full shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500"
+              className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-full shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
             >
               {mode === 'signin'
                 ? 'Create an account'

--- a/app/globals.css
+++ b/app/globals.css
@@ -89,8 +89,8 @@
     --card-foreground: 222.2 84% 4.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: 24.6 95% 53.1%;
+    --primary-foreground: 0 0% 100%;
     --secondary: 210 40% 96.1%;
     --secondary-foreground: 222.2 47.4% 11.2%;
     --muted: 210 40% 96.1%;
@@ -101,7 +101,7 @@
     --destructive-foreground: 210 40% 98%;
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --ring: 24.6 95% 53.1%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -125,8 +125,8 @@
     --card-foreground: 210 40% 98%;
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 20.5 90.2% 48.2%;
+    --primary-foreground: 0 0% 100%;
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
     --muted: 217.2 32.6% 17.5%;
@@ -137,7 +137,7 @@
     --destructive-foreground: 210 40% 98%;
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --ring: 20.5 90.2% 48.2%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
@@ -174,8 +174,8 @@
   --card-foreground: hsl(240 10% 3.9%);
   --popover: hsl(0 0% 100%);
   --popover-foreground: hsl(240 10% 3.9%);
-  --primary: hsl(240 5.9% 10%);
-  --primary-foreground: hsl(0 0% 98%);
+  --primary: hsl(24.6 95% 53.1%);
+  --primary-foreground: hsl(0 0% 100%);
   --secondary: hsl(240 4.8% 95.9%);
   --secondary-foreground: hsl(240 5.9% 10%);
   --muted: hsl(240 4.8% 95.9%);
@@ -186,7 +186,7 @@
   --destructive-foreground: hsl(0 0% 98%);
   --border: hsl(240 5.9% 90%);
   --input: hsl(240 5.9% 90%);
-  --ring: hsl(240 10% 3.9%);
+  --ring: hsl(24.6 95% 53.1%);
   --chart-1: hsl(12 76% 61%);
   --chart-2: hsl(173 58% 39%);
   --chart-3: hsl(197 37% 24%);
@@ -206,8 +206,8 @@
   --card-foreground: hsl(0 0% 98%);
   --popover: hsl(240 10% 3.9%);
   --popover-foreground: hsl(0 0% 98%);
-  --primary: hsl(0 0% 98%);
-  --primary-foreground: hsl(240 5.9% 10%);
+  --primary: hsl(20.5 90.2% 48.2%);
+  --primary-foreground: hsl(0 0% 100%);
   --secondary: hsl(240 3.7% 15.9%);
   --secondary-foreground: hsl(0 0% 98%);
   --muted: hsl(240 3.7% 15.9%);
@@ -218,7 +218,7 @@
   --destructive-foreground: hsl(0 0% 98%);
   --border: hsl(240 3.7% 15.9%);
   --input: hsl(240 3.7% 15.9%);
-  --ring: hsl(240 4.9% 83.9%);
+  --ring: hsl(20.5 90.2% 48.2%);
   --chart-1: hsl(220 70% 50%);
   --chart-2: hsl(160 60% 45%);
   --chart-3: hsl(30 80% 55%);

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -6,7 +6,7 @@ export default function NotFound() {
     <div className="flex items-center justify-center min-h-[100dvh]">
       <div className="max-w-md space-y-8 p-4 text-center">
         <div className="flex justify-center">
-          <CircleIcon className="size-12 text-orange-500" />
+          <CircleIcon className="size-12 text-primary" />
         </div>
         <h1 className="text-4xl font-bold text-gray-900 tracking-tight">
           Page Not Found
@@ -17,7 +17,7 @@ export default function NotFound() {
         </p>
         <Link
           href="/"
-          className="max-w-48 mx-auto flex justify-center py-2 px-4 border border-gray-300 rounded-full shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500"
+          className="max-w-48 mx-auto flex justify-center py-2 px-4 border border-gray-300 rounded-full shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
         >
           Back to Home
         </Link>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -16,9 +16,7 @@ const badgeVariants = cva(
           'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
         outline: 'text-foreground',
         success:
-          'border-transparent bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100',
-        warning:
-          'border-transparent bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100',
+          'border-transparent bg-accent text-accent-foreground hover:bg-accent/80',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## prompt 1
```
フロントエンドコンポーネント管理方針で以下を変えたいと思っています
 - フロントエンドのコンポーネントは基本的にshadcnを使うようにして、使い回せるコンポネントはuiディレクトリ配下に置いてほしい
 - カラースキーマーがsaas-starterを踏襲していないものがあるので、すべて踏襲するようにしてほしい

----

CLAUDE.mdに追加するのは
以下のようなものを想定していましたが、過不足あれば考慮して修正してください

----


## UI Component Guidelines

### Component Library
- Use shadcn/ui components as the foundation
- Custom components should be placed in `/components/ui/*`
- Reusable business components go in `/components/*`

### Styling
- Follow the existing color scheme from SaaS Starter
- Use Tailwind utility classes
- Reference design tokens from `tailwind.config.js`

### Component Structure
```typescript
// Preferred pattern
interface Props {
  // Props definition
}

export function ComponentName({ ...props }: Props) {
  // Implementation
}
```

## prompt2
```
記事管理機能について
UI Component Guidelinesの原則に従っていないコードを原則に従うように修正してください
```