### PR TITLE
chore: rename service name from ACME to OpenNote

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -85,7 +85,7 @@ function Header() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
         <Link href="/" className="flex items-center">
           <CircleIcon className="h-6 w-6 text-primary" />
-          <span className="ml-2 text-xl font-semibold text-foreground">ACME</span>
+          <span className="ml-2 text-xl font-semibold text-foreground">OpenNote</span>
         </Link>
         <div className="flex items-center space-x-4">
           <ThemeToggle />


### PR DESCRIPTION
このPRは Issue #15 を解決します。

- ダッシュボードヘッダーのブランド名を `ACME` から `OpenNote` に変更
- 対象ファイル: `app/(dashboard)/layout.tsx`

確認事項:
- 画面右上のヘッダー左側に表示されるサービス名が `OpenNote` に変わっていること

fixes #15