### PR TITLE
chore: rename service to OpenNote

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -85,7 +85,7 @@ function Header() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
         <Link href="/" className="flex items-center">
           <CircleIcon className="h-6 w-6 text-primary" />
-          <span className="ml-2 text-xl font-semibold text-foreground">ACME</span>
+          <span className="ml-2 text-xl font-semibold text-foreground">OpenNote</span>
         </Link>
         <div className="flex items-center space-x-4">
           <ThemeToggle />


### PR DESCRIPTION
Issue: #15

- サービス名称を ACME から OpenNote へ変更
- 対象: `app/(dashboard)/layout.tsx` のヘッダ表示

必要に応じて他箇所の表記ゆれが見つかった場合は、別PRで追随します。